### PR TITLE
While making pytest work as well as pyCharm testrunner, fixed some directory and project stuff.

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,11 @@
 
 library for batch-oriented complex data integration pipelines
 
-To setup and run tests:
-* venv recommended
+To setup project:
+* python -m venv venv
 * pip install -r requirements
+* pip install -e .  # installs the phaser library (in edit mode!) so pytest can import it
+
+To run:
+* source venv/bin/activate
 * pytest

--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -1,1 +1,2 @@
 from phaser.phase import Phase
+__version__ = 0.1

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -1,4 +1,5 @@
 import os
+from pathlib import PosixPath
 import pandas as pd
 
 class Phase:
@@ -10,9 +11,15 @@ class Phase:
         self.initialize_values()
 
     def initialize_values(self):
-        self.source_filename = self.source.split('/')[-1]
+        if isinstance(self.source, str):
+            self.source_filename = os.path.basename(self.source)
+        elif isinstance(self.source, PosixPath):
+            self.source_filename = self.source.name
+        else:
+            raise ValueError("Source filename attribute 'source' is not a string or Path")
+
         if not os.path.exists(self.working_dir):
-            raise Exception(f"Working dir {self.working_dir} does not exist.")
+            raise ValueError(f"Working dir {self.working_dir} does not exist.")
         destination_filename = '-'.join([self.__class__.__name__, self.source_filename])
         self.destination = os.path.join(self.working_dir, destination_filename)
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,7 @@
+[build-system]
+requires = ["hatchling"]
+build-backend = "hatchling.build"
+
+[project]
+name = "phaser"
+version = "0.1"

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,11 +1,14 @@
 from phaser import Phase
 import pytest
 import os
+from pathlib import Path
 
-def test_load_and_save():
+current_path = Path(__file__).parent
+
+def test_load_and_save(tmpdir):
     class Transformer(Phase):
-        source = "fixtures/employees.csv"
-        working_dir = "tmp"
+        source = current_path / "fixtures" / "employees.csv"
+        working_dir = tmpdir
 
     Transformer().run()
-    assert os.path.exists("tmp/Transformer-employees.csv")
+    assert os.path.exists(os.path.join(tmpdir, "Transformer-employees.csv"))


### PR DESCRIPTION
* First thing blocking pytest was that the library wasn't installed in pip.  Provides library definition in pyproject.toml, then "run pip install -e ."
* Added more setup info to README.md because of these steps.  
* Then pytest wasn't working because of the relative directory to the fixture.  Improved that by figuring out what the present directory is before loading fixture.
* While doing that, made the Phase object setup more flexible: source file can be a string or path object.
* Using the pytest builtin fixture for a temporary directory for output is cleaner 
