### PR TITLE
Updates instructions for setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,11 +24,11 @@ by shortening the loop on debugging where a complex data integration is failing.
 
 To setup project for contributing:
 * python -m venv venv
-* pip install -r requirements
+* source venv/bin/activate
+* pip install -r requirements.txt
 * pip install -e .  # installs the phaser library (in edit mode!) so pytest can import it
 
 Then run:
-* source venv/bin/activate
 * pytest
 
 


### PR DESCRIPTION
As a Python newbie, I changed the order of operations for project  setup that made more sense to me, namely activating the virtual environment before proceeding with `pip install` calls. I'm guessing that installs the dependencies in my local virtual environment rather than my computer's global install site, which is what I want.  Also, added the `.txt` to the install command, as it seemed to be required on my computer.