### PR TITLE
Refactors step decorators with better ideas

### DIFF
--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -1,15 +1,19 @@
 from functools import wraps
 
+ROW_STEP = "ROW_STEP"
+BATCH_STEP = "BATCH_STEP"
+DATAFRAME_STEP = "DATAFRAME_STEP"
+PROBE_VALUE = "__PROBE__"
 
 def row_step(step_function):
     """ This decorator is used to indicate a step that should run on each row of a data set.
     It adds a "probe" response to the step that allows the phase running logic to know this.
     """
     @wraps(step_function)
-    def _row_step_wrapper(phase, row):
-        if row == "__PROBE__":
-            return "row_step"  # Allows Phase to probe a step for how to call it
-        result = step_function(phase, row)
+    def _row_step_wrapper(row, context=None, __probe__=None):
+        if __probe__ == PROBE_VALUE:
+            return ROW_STEP  # Allows Phase to probe a step for how to call it
+        result = step_function(row, context=context)
         assert isinstance(result, dict)
         return result
     return _row_step_wrapper
@@ -20,10 +24,10 @@ def batch_step(step_function):
     whole batch by adding a 'probe' response
     """
     @wraps(step_function)
-    def _batch_step_wrapper(phase, batch):
-        if batch == "__PROBE__":
-            return "batch_step"
-        result = step_function(phase, batch)
+    def _batch_step_wrapper(batch, context=None, __probe__=None):
+        if __probe__ == PROBE_VALUE:
+            return BATCH_STEP
+        result = step_function(batch, context=context)
         assert isinstance(result, list)
         return result
     return _batch_step_wrapper
@@ -40,7 +44,7 @@ def check_unique(column_name, strip=True, ignore_case=False):
     """
 
     @batch_step
-    def check_unique_step(phase, batch):
+    def check_unique_step(batch, **kwargs):
         values = [row.get(column_name) for row in batch]
         if strip:
             values = [value.strip() for value in values]

--- a/tests/fixtures.py
+++ b/tests/fixtures.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from phaser import row_step, Phase, check_unique
 
 @row_step
-def null_step(phase, row):
+def null_step(row, **kwargs):
     return row
 
 
@@ -27,7 +27,7 @@ def reconcile_phase_class(tmpdir):
         MOCK_EXTERNAL_DATA = ['rabbit', 'pillow', 'clock', 'lintroller', 'bird', 'smokedetector']
 
         @row_step
-        def check_known_symbols(self, row):
+        def check_known_symbols(row, **kwargs):
             if 'symbol' in row.keys():
                 assert row['symbol'] in Reconciler.MOCK_EXTERNAL_DATA
             return row

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -38,7 +38,7 @@ def test_subclassing(tmpdir):
 
 
 @row_step
-def full_name_step(phase, row):
+def full_name_step(row, **kwargs):
     row["full name"] = " ".join([row["First name"], row["Last name"]])
     return row
 

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1,7 +1,7 @@
 from pathlib import Path
 import pytest
 
-from phaser import check_unique, Phase
+from phaser import check_unique, Phase, row_step
 from fixtures import test_data_phase_class
 
 current_path = Path(__file__).parent
@@ -26,20 +26,32 @@ def test_check_unique_fails(test_data_phase_class):
 def test_check_unique_strips_spaces():
     fn = check_unique('id')
     with pytest.raises(AssertionError):
-        fn(None, [{'id': " 1 "}, {'id': '1'}])
+        fn([{'id': " 1 "}, {'id': '1'}])
 
 
 def test_check_unique_without_stripping():
     fn = check_unique('name', strip=False)
-    fn(None, [{'name': '  Sam'}, {'name': 'Sam'}])
+    fn([{'name': '  Sam'}, {'name': 'Sam'}])
 
 
 def test_check_unique_case_sensitive():
     fn = check_unique('dept')
-    fn(None, [{'dept': "ENG"}, {'dept': 'Sales'}, {'dept': "eng"}])
+    fn([{'dept': "ENG"}, {'dept': 'Sales'}, {'dept': "eng"}])
 
 
 def test_check_unique_case_insensitive():
     fn = check_unique('dept', ignore_case=True)
     with pytest.raises(AssertionError):
-        fn(None, [{'dept': "ENG"}, {'dept': 'Sales'}, {'dept': "Eng"}])
+        fn([{'dept': "ENG"}, {'dept': 'Sales'}, {'dept': "Eng"}])
+
+
+def test_context_available_to_step():
+    @row_step
+    def replace_value_fm_context(row, context):
+        row['secret'] = context['secret']
+        return row
+
+    transformer = Phase(steps=[replace_value_fm_context], context={'secret': "I'm always angry"})
+    transformer.row_data = [ {'id': 1, 'secret': 'unknown'}]
+    transformer.run_steps()
+    assert transformer.row_data[0]['secret'] == "I'm always angry"


### PR DESCRIPTION
Fixes #4 

* Instead of hacking a special value to do probing, the step decorators handle a special parameter that isn't passed to the step itself.
* Instead of passing the phase to steps for context (information that the user would like all steps to have, like company_id or timezone to interpret dates in) , use a context dictionary.
