### PR TITLE
Adds a test that confirms what happens if a field is dropped from a row

### DIFF
--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -230,7 +230,6 @@ class Phase:
                     self.context.add_warning('consistency_check',
                                              row.get(Pipeline.ROW_NUM_FIELD, 'unknown'),
                         f"At some point, {field_name} was added to the row_data and not declared a header")
-        # LMDTODO: We could also check for fields dropped in row_data steps and add them if they can be null?
 
     def run_steps(self):
         if self.row_data is None or self.row_data == []:


### PR DESCRIPTION
When not skipped, this test shows that a 'nan' is saved in this IntColumn where the min_value is supposed to be 1. 

I did delete the LMDTODO column on the test just above intentionally - the error DOES state the column name, just not within the step name, which seems fine. 