### PR TITLE
Fixes the output of warnings

### DIFF
--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -114,8 +114,10 @@ class Phase:
         these fit very nicely into the standard levels allowing familiar customization.  """
         for row_num, info in self.context.dropped_rows.items():
             print(f"DROPPED row: {row_num}, message: '{info['message']}'")
-        for row_num, warning in self.context.warnings.items():
-            print(f"WARNING row: {row_num}, message: '{warning['message']}'")
+        # Unlike errors and dropped rows, there can be multiple warnings per row
+        for row_num, warnings in self.context.warnings.items():
+            for warning in warnings:
+                print(f"WARNING row: {row_num}, message: '{warning['message']}'")
         for row_num, error in self.context.errors.items():
             print(f"ERROR row: {row_num}, message: '{error['message']}'")
 


### PR DESCRIPTION
Unlike errors and dropped rows, there can be multiple warnings per row, so when we output them, we need to iterate through a list of warnings per row.