### PR TITLE
Adds very basic functionality to diff step output

### DIFF
--- a/phaser/cli/commands/run.py
+++ b/phaser/cli/commands/run.py
@@ -27,6 +27,7 @@ from phaser.cli import Command
 
 class RunPipelineCommand(Command):
     def add_arguments(self, parser):
+        parser.add_argument("--diff", help="diff step output", action="store_true")
         parser.add_argument("pipeline_name", help="pipeline to run")
         parser.add_argument("working_dir", help="directory to output phase results")
         parser.add_argument("source", help="file to use as initial source")
@@ -57,5 +58,5 @@ class RunPipelineCommand(Command):
         source = args.source
 
         print(f"Running pipeline '{Pipeline.__name__}'")
-        pipeline = Pipeline(working_dir, source)
+        pipeline = Pipeline(working_dir, source, diff=args.diff)
         pipeline.run()

--- a/phaser/differ.py
+++ b/phaser/differ.py
@@ -1,0 +1,46 @@
+from pandas import isna
+from .phase import Phase
+
+def is_not_equal(a, b):
+    """
+    Returns true if a and b are not equal, taking into account pandas.NA and
+    numpy.nan, treating NA and nan as equal to themselves and each other
+    """
+    if a is b:
+        return False
+    if isna(a) & isna(b):
+        return False
+    if isna(a) | isna(b):
+        return True
+    return a != b
+
+def diff_row(a, b, no_key=None):
+    # Thank you: https://code.activestate.com/recipes/576644-diff-two-dictionaries/#c9
+    both = a.keys() & b.keys()
+    diff = {k:(a[k], b[k]) for k in both if is_not_equal(a[k], b[k])}
+    diff.update({k:(a[k], no_key) for k in a.keys() - both})
+    diff.update({k:(no_key, b[k]) for k in b.keys() - both})
+    return diff
+
+# TODO: Actually implement this
+def diff_rows(aa, bb):
+    return aa + bb
+
+# A Phase that wraps and delegates to another Phase, adding in logic to run
+# diffs of the data as it is transformed.
+class DiffingPhase(Phase):
+    def __init__(self, phase):
+        super().__init__(phase.name, phase.steps, phase.columns, phase.context, phase.default_error_policy)
+
+    def execute_row_step(self, step):
+        def _step(row, **kwargs):
+            # TODO: If the step mutates the row, no diffs will show up. Either
+            # send in a deep copy, or capture the mutations through
+            # metaprogramming like overwriting `__setitem__`.
+            new_row = step(row, **kwargs)
+            diff = diff_row(row, new_row)
+            if len(diff) > 0:
+                print(f"DIFF {step.__name__}: {diff}")
+            return new_row
+        _step.__name__ = f"wrapped({step.__name__})"
+        super().execute_row_step(_step)

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -85,9 +85,8 @@ class Phase:
         self.columns = columns or self.__class__.columns
         if isinstance(self.columns, Column):
             self.columns = [self.columns]
-        if not context:
-            # If a phase is being run in isolation and without the pipeline context, create a new one
-            self.context = Context()
+        # If a phase is being run in isolation and without the pipeline context, create a new one
+        self.context = context or Context()
 
         self.row_data = []
         self.headers = None

--- a/tests/test_differ.py
+++ b/tests/test_differ.py
@@ -1,0 +1,103 @@
+import numpy
+import pandas
+import pytest
+import phaser
+from phaser.differ import DiffingPhase, diff_row, diff_rows, is_not_equal
+
+@pytest.mark.parametrize("a, b, expected",
+    [
+        ({}, {}, {}),
+        # Change all fields
+        ({'name': 'Kirk', 'crew id': 1},
+         {'name': 'McCoy', 'crew id': 2},
+         {'name': ('Kirk', 'McCoy'), 'crew id': (1, 2)}),
+        # Change no fields
+        ({'name': 'Kirk', 'crew id': 1},
+         {'name': 'Kirk', 'crew id': 1},
+         {}),
+        # Change a single field
+        ({'name': 'Kirk', 'crew id': 1},
+         {'name': 'Kirk', 'crew id': 10},
+         {'crew id': (1, 10)}),
+        # Add a field
+        ({'name': 'Kirk', 'crew id': 1},
+         {'name': 'Kirk', 'crew id': 1, 'rank': 'Captain'},
+         {'rank': (None, 'Captain')}),
+        # Remove a field
+        ({'name': 'Kirk', 'crew id': 1, 'rank': 'Captain'},
+         {'name': 'Kirk', 'crew id': 1},
+         {'rank': ('Captain', None)}),
+        # Treat NA as equal to NA, even though Pandas does not
+        ({'name': pandas.NA},
+         {'name': pandas.NA},
+         {}),
+        # Treat nan as equal to nan, even though numpy does not
+        ({'name': numpy.nan},
+         {'name': numpy.nan},
+         {}),
+
+    ]
+)
+def test_diff_row(a, b, expected):
+    diff = diff_row(a, b)
+    assert diff == expected
+
+@pytest.mark.skip
+@pytest.mark.parametrize("aa, bb, expected",
+    [
+        ([], [], []),
+        ([1], [2], [1, 2]),
+    ]
+)
+def test_diff_rows(aa, bb, expected):
+    diff = diff_rows(aa, bb)
+    assert diff == expected
+
+@pytest.mark.parametrize("a, b, expected",
+    [
+        (pandas.NA, pandas.NA, False),
+        (numpy.nan, numpy.nan, False),
+        (pandas.NA, numpy.nan, False),
+        (numpy.nan, pandas.NA, False),
+        ('a', pandas.NA, True),
+        (pandas.NA, 'b', True),
+        ('a', numpy.nan, True),
+        (numpy.nan, 'b', True),
+        ('a', 'b', True),
+        (['a'], ['a'], False),
+    ]
+)
+def test_not_equal(a, b, expected):
+    assert is_not_equal(a, b) == expected
+
+def test_diffing_phase(tmpdir):
+    @phaser.row_step
+    def null_step(row, **kwargs):
+        return row
+
+    @phaser.row_step
+    def change_step(row, **kwargs):
+        new_row = {
+            'name': row['name'] + '-change',
+            'age': row['age'] + 20,
+        }
+        return new_row
+
+    data = [
+        {'name': 'Wonderkid', 'age': 16},
+        {'name': 'Wonderbaby', 'age': 2},
+    ]
+    phase = phaser.Phase(
+        name="inner phase",
+        steps=[
+            null_step,
+            change_step,
+        ],
+    )
+    diffing_phase = DiffingPhase(phase)
+    diffing_phase.load_data(data)
+    diffing_phase.run_steps()
+    assert diffing_phase.row_data == [
+        {'name': 'Wonderkid-change', 'age': 36},
+        {'name': 'Wonderbaby-change', 'age': 22},
+    ]


### PR DESCRIPTION
Adds a switch (`--diff`) to use in running a pipeline through the command line app. When in use, the changes that are made to each row are output to stdout after each step.

This does not capture rows that are dropped or added and is only implemented for `@row_step`s.