### PR TITLE
Adds row metadata to a new class

### DIFF
--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -1,3 +1,4 @@
+from collections import UserDict, UserList
 import pandas as pd
 import logging
 from .column import make_strict_name, Column
@@ -89,7 +90,7 @@ class Phase:
             # If a phase is being run in isolation and without the pipeline context, create a new one
             self.context = Context()
 
-        self.row_data = []
+        self.row_data = PhaseRecords()
         self.headers = None
         self.default_error_policy = error_policy or Pipeline.ON_ERROR_COLLECT
 
@@ -149,7 +150,7 @@ class Phase:
             # this would preserve original row numbers across data.  can't be done in reshape phases.
         else:
             df[Pipeline.ROW_NUM_FIELD] = df.reset_index().index
-        self.row_data = df.to_dict('records')
+        self.row_data = PhaseRecords(df.to_dict('records'))
 
     def load_data(self, data):
         """ Alternate load method is useful in tests or in scripting Phase class where the data is not in a file.
@@ -157,7 +158,7 @@ class Phase:
         format) """
         if len(data) > 0:
             self.headers = data[0].keys()
-        self.row_data = data
+        self.row_data = PhaseRecords(data)
 
     def do_column_stuff(self):
         @row_step
@@ -196,20 +197,23 @@ class Phase:
                 name = rename_list[name]  # Do declared renames
             return name
 
-        self.row_data = [{rename_me(key): value for key, value in row.items()} for row in self.row_data]
+        self.row_data = PhaseRecords([{rename_me(key): value for key, value in row.items()} for row in self.row_data])
         self.headers = [rename_me(name) for name in self.headers]
 
     def prepare_for_save(self):
         """ Checks consistency of data and drops unneeded columns
         """
         self.check_headers_consistent()
-        df = pd.DataFrame(self.row_data)
+        # Use the raw list(dict) form of the data, because DataFrame
+        # construction does something different with a subclass of Sequence and
+        # Mapping that results in the columns being re-ordered.
+        df = pd.DataFrame(self.row_data.to_records())
         columns_to_drop = [col.name for col in self.columns if col.save is False]
         # LMDTODO: Should saving row numbers be an option?
         columns_to_drop.append(Pipeline.ROW_NUM_FIELD)
         columns_exist_to_drop = [col_name for col_name in columns_to_drop if col_name in df.columns]
         df.drop(columns_exist_to_drop, axis=1, inplace=True)
-        self.row_data = df.to_dict('records')
+        self.row_data = PhaseRecords(df.to_dict('records'))
 
     def save(self, destination):
         """ This method saves the result of the Phase operating on the batch in phaser's preferred approach.
@@ -222,7 +226,10 @@ class Phase:
         * compression will be attempted if filename ends in 'zip', 'gzip', 'tar' etc
         """
 
-        pd.DataFrame(self.row_data).to_csv(destination, index=False, na_rep="NULL")
+        # Use the raw list(dict) form of the data, because DataFrame
+        # construction does something different with a subclass of Sequence and
+        # Mapping that results in the columns being re-ordered.
+        pd.DataFrame(self.row_data.to_records()).to_csv(destination, index=False, na_rep="NULL")
         logger.info(f"{self.name} saved output to {destination}")
 
     def check_headers_consistent(self):
@@ -274,7 +281,9 @@ class Phase:
                 if not isinstance(exc, DropRowException):
                     new_data.append(row)  # If we are continuing, keep the row in the data unchanged unless it's a
                     # DropRowException. (If the caller wants to change the row and also throw an exception, they can't)
-        self.row_data = new_data
+        # TODO: Make sure the row number is correctly captured and is the same
+        # as it was before the step.
+        self.row_data = PhaseRecords(new_data)
 
     def process_exception(self, exc, step, row):
         if isinstance(exc, DropRowException):
@@ -309,9 +318,26 @@ class Phase:
                 self.context.add_warning(step, None, f"{row_size_diff} rows were dropped by step")
             elif row_size_diff < 0:
                 self.context.add_warning(step, None, f"{abs(row_size_diff)} rows were ADDED by step")
-            self.row_data = [row for row in new_row_values]
+            self.row_data = PhaseRecords([row for row in new_row_values])
         except Exception as exc:
             self.process_exception(exc, step, None)
 
 
 # LMDTODO: add a test that makes sure that a batch step followed by a row step works fine
+
+class PhaseRecords(UserList):
+    def __init__(self, *args):
+        super().__init__(*args)
+        self.data = [
+            PhaseRecord(index, record)
+            for index, record in enumerate(self.data)
+        ]
+
+    # Transform back into native list(dict)
+    def to_records(self):
+        return [ r.data for r in self.data ]
+
+class PhaseRecord(UserDict):
+    def __init__(self, row_num, record):
+        super().__init__(record)
+        self.row_num = row_num

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -93,8 +93,6 @@ class Pipeline:
     source = None
     phases = []
 
-    ROW_NUM_FIELD = "__phaser_row_num__"
-
     ON_ERROR_WARN = "ON_ERROR_WARN"
     ON_ERROR_COLLECT = "ON_ERROR_COLLECT"
     ON_ERROR_DROP_ROW = "ON_ERROR_DROP_ROW"

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -1,3 +1,4 @@
+from collections.abc import Mapping, Sequence
 from functools import wraps
 from .pipeline import PipelineErrorException, PhaserException
 from .column import Column
@@ -18,7 +19,7 @@ def row_step(step_function):
         result = step_function(row, context=context)
         if result is None:
             raise PipelineErrorException("Step should return row.")
-        if not isinstance(result, dict):
+        if not isinstance(result, Mapping):
             raise PipelineErrorException(f"Step should return row in dict format, not {result}")
         return result
     return _row_step_wrapper
@@ -33,7 +34,7 @@ def batch_step(step_function):
         if __probe__ == PROBE_VALUE:
             return BATCH_STEP
         result = step_function(batch, context=context)
-        if not isinstance(result, list):
+        if not isinstance(result, Sequence):
             raise PipelineErrorException(
                 f"Step {step_function} returned a {result.__class__} rather than a list of rows")
         return result

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -25,7 +25,6 @@ def test_pipeline_source_none(tmpdir, reconcile_phase_class):
         p = Pipeline(phases=[reconcile_phase_class], working_dir=tmpdir)
         p.run()
 
-
 def test_load_and_save(tmpdir):
     source = current_path / "fixture_files" / "crew.csv"
     dest = os.path.join(tmpdir, "Transformed-crew.csv")

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -62,7 +62,7 @@ def test_error_provides_info(reconcile_phase_class):
 
     phase.run_steps()
     error = phase.context.errors[0]
-    assert error['row'][Pipeline.ROW_NUM_FIELD] == 0
+    assert error['row'].row_num == 0
     assert error['row']['deck'] == '21'
     assert error['step'] == 'assert_false'
     assert error['message'] == "AssertionError raised (assert False)"


### PR DESCRIPTION
In writing a pipeline, I found it easy to accidentally remove the data stored in `__phaser_row_num__`.  That experience, along with thinking about how we may want to store diff data for records, led me to think about keeping metadata for rows in a special class that looks and feels like a `dict` to the user but includes metadata that should not be changed.  (I'd say "cannot" be changed, but that would probably take an unnecessary amount of Python metaprogramming to implement private attributes.)