### PR TITLE
Adds context_step - this can initiate or format data in context

### DIFF
--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -29,7 +29,7 @@ have datatype casting and name canonicalization done automatically.
 
 from phaser.pipeline import Pipeline, PipelineErrorException, PhaserException, DropRowException, WarningException
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
-from phaser.steps import row_step, batch_step, check_unique, sort_by
+from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn
 
 __version__ = 0.1

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -5,6 +5,7 @@ from .column import Column
 
 ROW_STEP = "ROW_STEP"
 BATCH_STEP = "BATCH_STEP"
+CONTEXT_STEP = "CONTEXT_STEP"
 PROBE_VALUE = "__PROBE__"
 
 def row_step(step_function):
@@ -38,6 +39,15 @@ def batch_step(step_function):
                 f"Step {step_function} returned a {result.__class__} rather than a list of rows")
         return result
     return _batch_step_wrapper
+
+
+def context_step(step_function):
+    @wraps(step_function)
+    def _context_step_wrapper(context, __probe__=None):
+        if __probe__ == PROBE_VALUE:
+            return CONTEXT_STEP
+        result = step_function(context)
+    return _context_step_wrapper
 
 
 def check_unique(column, strip=True, ignore_case=False):


### PR DESCRIPTION
This small feature is setting up to be able to handle extra_inputs and extra_outputs 
in regular phases.  The context_step can turn extra inputs into context variables, 
or turn variables into extra outputs. 