### PR TITLE
Move I/O to Pipeline, and introduce Context steps and saving extra outputs

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,30 +100,42 @@ Then run:
 
 ## Features
 
-The construction of a Phase instance means that you can put a bunch of data transformation or
-data testing steps in a series, and the Phase does routine work for you in a robust way:
+A phaser Pipeline organizes one or more Phases and does I/O, marshalling source data and
+checkpoint data between Phases.  It will
 
-* it will load your data from a source file or a previous phase
-* it will canonicalize field names to lowercase and strip dangerous characters
-* it will run your steps row-by-row in order
-* it will save your results to a different file, usable as a checkpoint
-* it will report errors or warnings as summaries 
+* load source data from files or a previous phase
+* save checkpoint data between phases
+* save outputs
+* marshall inputs and outputs between phases
+
+Each Phase runs one or more steps with individual data transformation or validation
+logic, and the Phase does routine work in a robust way:
+
+* transform column headers to preferred name/case
+* routine parsing and data typing
+* report errors or warnings as summaries
+
+Different kinds of Phases operate slightly differently:
+
+* regular Phase operates row-by-row and reports errors/warnings by row
+* regular Phase offer access to diffs to examine results or debug steps
+* reshaping Phases have fewer restrictions to allow data sources to be combined, split or reshaped
 
 Columns can be passed and formats and limits enforced at the beginning and at the end of Phases.
 Many steps that might otherwise have been programmed functionally are therefore available to
-declare.  Columns available so far:
+declare.  Columns and features available so far:
 
-* IntColumn
-* FloatColumn
-* DateColumn
-* DateTimeColumn
+* IntColumn, FloatColumn
+* DateColumn, DateTimeColumn
+* Range validation, list of allowed values
+* Checking for nulls/blanks, assigning default values
 
-Then, any remaining work can be done in granular steps, which operate row by row (rows are Python dicts).
+For your data pipeline project, most of the work unique to that project can be done within steps
+that operate in a Phase to give structure and debuggability:
 
-* Pre-baked steps are available to check uniqueness values and do common transforms
+* Steps are individually testable with simple pythonic ways to pass row data and verify results
 * Steps can drop rows with bad data
 * Steps can access context information
 * Steps can create warnings or errors
+* Pre-baked steps are available to check uniqueness values and do common transforms
 
-Phases that reshape the entire dataset or operate on the entire dataset are
-handled separately because the error reporting, error handling and diffs are different.

--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -29,7 +29,7 @@ have datatype casting and name canonicalization done automatically.
 
 from phaser.pipeline import Pipeline, PipelineErrorException, PhaserException, DropRowException, WarningException
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
-from phaser.steps import row_step, batch_step, check_unique, sort_by
+from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn
 
 __version__ = 0.1

--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -31,5 +31,6 @@ from phaser.pipeline import Pipeline, PipelineErrorException, PhaserException, D
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
 from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn
+from phaser.util import read_csv
 
 __version__ = 0.1

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -93,14 +93,12 @@ class DataFramePhase(PhaseBase):
     def run(self, destination):
         self.df_data = self.df_transform(self.df_data)
         self.report_errors_and_warnings()
-        if self.context.has_errors():
-            raise PipelineErrorException(f"Phase '{self.name}' failed with {len(self.context.errors.keys())} errors.")
         return self.df_data.to_dict('records')
 
     @abstractmethod
     def df_transform(self, df_data):
         """ The df_transform method is implemented in subclasses of DataFramePhase.  Significant reshaping can be
-
+        done because data is not processed row-by-row, and row numbers are not reported on in error reporting.
         """
         raise PhaserException("Subclass DataFramePhase and return a new dataframe in the 'df_transform' method")
 
@@ -134,8 +132,6 @@ class ReshapePhase(PhaseBase):
     def run(self):
         self.row_data = self.reshape(self.row_data)
         self.report_errors_and_warnings()
-        if self.context.has_errors():
-            raise PipelineErrorException(f"Phase '{self.name}' failed with {len(self.context.errors.keys())} errors.")
         return self.row_data
 
     def save(self, destination):
@@ -229,12 +225,8 @@ class Phase(PhaseBase):
         # Break down run into load, steps, error handling, save and delegate
         self.do_column_stuff()
         self.run_steps()
-        if self.context.has_errors():
-            self.report_errors_and_warnings()
-            raise PipelineErrorException(f"Phase '{self.name}' failed with {len(self.context.errors.keys())} errors.")
-        else:
-            self.report_errors_and_warnings()
-            self.prepare_for_save()
+        self.report_errors_and_warnings()
+        self.prepare_for_save()
         return self.row_data.to_records()
 
     def do_column_stuff(self):

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -1,6 +1,7 @@
 from abc import ABC, abstractmethod
 from collections import UserDict, UserList
 import pandas as pd
+from pathlib import Path
 import logging
 from .column import make_strict_name, Column
 from .pipeline import Pipeline, Context, DropRowException, WarningException, PipelineErrorException, PhaserException
@@ -37,11 +38,11 @@ class PhaseBase(ABC):
         * Raises errors loading 'bad lines', rather than skip
         """
         return pd.read_csv(source,
-                         dtype='str',
-                         sep=',',
-                         skip_blank_lines=True,
-                         index_col=False,
-                         comment='#')
+                           dtype='str',
+                           sep=',',
+                           skip_blank_lines=True,
+                           index_col=False,
+                           comment='#')
 
     def load(self, source):
         """ When creating a Phase, it may be desirable to subclass it and override the load()
@@ -67,6 +68,9 @@ class PhaseBase(ABC):
         # Use the raw list(dict) form of the data, because DataFrame
         # construction does something different with a subclass of Sequence and
         # Mapping that results in the columns being re-ordered.
+        if not isinstance(destination, str):
+            if Path(destination).is_dir():
+                destination = destination / self.name
         pd.DataFrame(self.row_data.to_records()).to_csv(destination, index=False, na_rep="NULL")
         logger.info(f"{self.name} saved output to {destination}")
 

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -162,12 +162,41 @@ class Pipeline:
         next_source = self.source
         for phase in self.phase_instances:
             destination = self.get_destination(phase)
-            logger.info(f"Loading input from {next_source} for {phase.name}")
-            df = read_csv(next_source)
-            phase.load_data(df)
-            phase.run(destination=destination)
-            self.context.save_your_outputs(self.working_dir)
-            next_source = destination  # for next phase in chain
+            self.run_phase(phase, next_source, destination)
+            next_source = destination
+
+    def run_phase(self, phase, source, destination):
+        logger.info(f"Loading input from {source} for {phase.name}")
+        input = self.load(source)
+        phase.load_data(input)
+        results = phase.run()
+        self.save(results, destination)
+        self.context.save_your_outputs(self.working_dir)
+        logger.info(f"{phase.name} saved output to {destination}")
+
+    def load(self, next_source):
+        """ The load method can be overridden to apply a pipeline-specific way of loading data.
+        Phaser default is to read data from a CSV file. """
+        return read_csv(next_source).to_dict('records')
+
+    def save(self, results, destination):
+        """ This method saves the result of the Phase operating on the batch in phaser's preferred approach.
+        It should be easy to override this method to save in a different way, using different
+        parameters on pandas' to_csv, or to use pandas' to_excel, to_json or a different output entirely.
+
+        CSV defaults chosen:
+        * separator character is ','
+        * encoding is UTF-8
+        * compression will be attempted if filename ends in 'zip', 'gzip', 'tar' etc
+        """
+
+        # Use the raw list(dict) form of the data, because DataFrame
+        # construction does something different with a subclass of Sequence and
+        # Mapping that results in the columns being re-ordered.
+        if not isinstance(destination, str):
+            if Path(destination).is_dir():
+                destination = destination / self.name
+        pd.DataFrame(results).to_csv(destination, index=False, na_rep="NULL")
 
     def get_destination(self, phase):
         source_filename = None

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -2,6 +2,7 @@ import inspect
 import logging
 import os
 import pandas as pd
+from phaser.util import read_csv
 from pathlib import Path, PosixPath
 
 logger = logging.getLogger('phaser')
@@ -113,6 +114,9 @@ class ReadWriteObject:
         self.to_save = to_save
 
 
+
+
+
 class Pipeline:
     # Subclasses can override here to set values for all instances, or override in instantiation
     working_dir = None
@@ -158,7 +162,10 @@ class Pipeline:
         next_source = self.source
         for phase in self.phase_instances:
             destination = self.get_destination(phase)
-            phase.run(source=next_source, destination=destination)
+            logger.info(f"Loading input from {next_source} for {phase.name}")
+            df = read_csv(next_source)
+            phase.load_data(df)
+            phase.run(destination=destination)
             self.context.save_your_outputs(self.working_dir)
             next_source = destination  # for next phase in chain
 

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -173,6 +173,9 @@ class Pipeline:
         self.save(results, destination)
         self.context.save_your_outputs(self.working_dir)
         logger.info(f"{phase.name} saved output to {destination}")
+        if self.context.has_errors():
+            raise PipelineErrorException(f"Phase '{phase.name}' failed with {len(self.context.errors.keys())} errors.")
+
 
     def load(self, next_source):
         """ The load method can be overridden to apply a pipeline-specific way of loading data.

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -5,6 +5,7 @@ from .column import Column
 
 ROW_STEP = "ROW_STEP"
 BATCH_STEP = "BATCH_STEP"
+CONTEXT_STEP = "CONTEXT_STEP"
 PROBE_VALUE = "__PROBE__"
 
 def row_step(step_function):
@@ -38,6 +39,15 @@ def batch_step(step_function):
                 f"Step {step_function} returned a {result.__class__} rather than a list of rows")
         return result
     return _batch_step_wrapper
+
+
+def context_step(step_function):
+    @wraps(step_function)
+    def _context_step_wrapper(context, __probe__=None):
+        if __probe__ == PROBE_VALUE:
+            return CONTEXT_STEP
+        result = step_function(context)
+    return _context_step_wrapper
 
 
 def check_unique(column, strip=True, ignore_case=False):

--- a/phaser/util.py
+++ b/phaser/util.py
@@ -1,0 +1,22 @@
+import pandas as pd
+
+
+def read_csv(source):
+    """ Includes the default settings phaser uses with panda's read_csv. Can be overridden to provide
+    different read_csv settings.
+    Defaults:
+    * assume all column values are strings, so leading zeros or trailing zeros don't get destroyed.
+    * assume ',' value-delimiter
+    * skip_blank_lines=True: allows blank AND '#'-led rows to be skipped and still find header row
+    * doesn't use indexing
+    * does attempt to decompress common compression formats if file uses them
+    * assume UTF-8 encoding
+    * uses '#' as the leading character to assume a row is comment
+    * Raises errors loading 'bad lines', rather than skip
+    """
+    return pd.read_csv(source,
+                       dtype='str',
+                       sep=',',
+                       skip_blank_lines=True,
+                       index_col=False,
+                       comment='#')

--- a/tests/test_extra_ios.py
+++ b/tests/test_extra_ios.py
@@ -1,0 +1,34 @@
+import os
+from pathlib import Path
+import pytest
+from phaser import Phase, context_step, Pipeline
+
+current_path = Path(__file__).parent
+
+
+
+@context_step
+def add_an_output(context):
+    context.add_output('doctors', [{'on_call': "Julian Bashir"}])
+
+class EmployeePhase(Phase):
+    steps = [
+        add_an_output
+    ]
+
+class MyPipeline(Pipeline):
+    phases = [EmployeePhase]
+    source = current_path / 'fixture_files' / 'crew.csv'
+
+
+def test_extra_outputs(tmpdir):
+    pipeline = MyPipeline(working_dir=tmpdir)
+    pipeline.run()
+    assert os.path.exists(tmpdir / 'doctors.csv')
+
+
+@pytest.mark.skip("This doesn't work yet - the pipeline tells the context when to save extra outputs")
+def test_extra_outputs_without_phase(tmpdir):
+    phase = EmployeePhase()
+    phase.run(current_path / "fixture_files" / "crew.csv", tmpdir)
+    assert os.path.exists(tmpdir / 'employee_phase_managers.csv')

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -6,7 +6,7 @@ from phaser import ReshapePhase, DataFramePhase, read_csv
 
 current_path = Path(__file__).parent
 
-def test_reshape(tmpdir):
+def test_reshape():
 
     class MyReshape(ReshapePhase):
         def reshape(self, row_data):
@@ -22,7 +22,7 @@ def test_reshape(tmpdir):
 
     phase = MyReshape("myreshape")
     phase.load_data(read_csv(current_path / 'fixture_files' / 'locations.csv'))
-    phase.run(tmpdir/'output.csv')
+    phase.run()
     assert len(phase.row_data) == 2
     assert phase.row_data == [
         {'location': 'hangar deck', 'temperature': '16', 'gamma radiation': '9.8 μR/h'},

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -1,8 +1,8 @@
 import pytest
 from pathlib import Path
 from collections import defaultdict
-from pandas import DataFrame, pivot, read_csv
-from phaser import ReshapePhase, DataFramePhase
+import pandas as pd
+from phaser import ReshapePhase, DataFramePhase, read_csv
 
 current_path = Path(__file__).parent
 
@@ -21,7 +21,8 @@ def test_reshape(tmpdir):
             return location_list
 
     phase = MyReshape("myreshape")
-    phase.run(current_path / 'fixture_files' / 'locations.csv', tmpdir/'output.csv')
+    phase.load_data(read_csv(current_path / 'fixture_files' / 'locations.csv'))
+    phase.run(tmpdir/'output.csv')
     assert len(phase.row_data) == 2
     assert phase.row_data == [
         {'location': 'hangar deck', 'temperature': '16', 'gamma radiation': '9.8 μR/h'},
@@ -35,7 +36,8 @@ def test_dataframe_phase(tmpdir):
             return df.pivot(index='location', columns='measure', values='value').reset_index()
 
     phase = MyPandasPhase("MyPandasPhase")
-    phase.run(current_path / 'fixture_files' / 'locations.csv', tmpdir / 'output.csv')
+    phase.load_data(read_csv(current_path / 'fixture_files' / 'locations.csv'))
+    phase.run( tmpdir / 'output.csv')
     row_data = phase.df_data.to_dict('records')
     assert len(row_data) == 2
     assert row_data == [
@@ -63,7 +65,8 @@ def test_reshape_explode(tmpdir):
         csv.write('2,"Standard,Vulcan,Romulan"\n')
         csv.write('3,"Standard,Klingon"\n')
 
-    phase.run(source=tmpdir/'languages.csv', destination=tmpdir/'language_list.csv')
+    phase.load_data(read_csv(tmpdir / 'languages.csv'))
+    phase.run(destination=tmpdir/'language_list.csv')
     row_data = phase.df_data.to_dict('records')
     assert len(row_data) == 6
     assert row_data[5]['language'] == "Klingon"

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -37,10 +37,9 @@ def test_dataframe_phase(tmpdir):
 
     phase = MyPandasPhase("MyPandasPhase")
     phase.load_data(read_csv(current_path / 'fixture_files' / 'locations.csv'))
-    phase.run( tmpdir / 'output.csv')
-    row_data = phase.df_data.to_dict('records')
-    assert len(row_data) == 2
-    assert row_data == [
+    results = phase.run()
+    assert len(results) == 2
+    assert results == [
         {'location': 'hangar deck', 'temperature': '16', 'gamma radiation': '9.8 μR/h'},
         {'location': 'main engineering', 'temperature': '22', 'gamma radiation': '10.9 μR/h'}
     ]
@@ -66,7 +65,6 @@ def test_reshape_explode(tmpdir):
         csv.write('3,"Standard,Klingon"\n')
 
     phase.load_data(read_csv(tmpdir / 'languages.csv'))
-    phase.run(destination=tmpdir/'language_list.csv')
-    row_data = phase.df_data.to_dict('records')
-    assert len(row_data) == 6
-    assert row_data[5]['language'] == "Klingon"
+    results = phase.run()
+    assert len(results) == 6
+    assert results[5]['language'] == "Klingon"

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pytest
 
 from phaser import (check_unique, Phase, row_step, context_step, Pipeline, sort_by, IntColumn,
-                    PipelineErrorException, DropRowException, PhaserException)
+                    PipelineErrorException, DropRowException, PhaserException, read_csv)
 from fixtures import test_data_phase_class
 
 current_path = Path(__file__).parent
@@ -28,7 +28,7 @@ def test_context_available_to_step():
 
 def test_builtin_step():
     phase = Phase(steps=[check_unique('crew id')])
-    phase.load(current_path / 'fixture_files' / 'crew.csv')
+    phase.load_data(read_csv(current_path / 'fixture_files' / 'crew.csv'))
     phase.run_steps()
 
 


### PR DESCRIPTION
I previously had a PR to save extra outputs, but wasn't entirely happy with it, but then we thought of moving I/O to Pipeline. 

I think this is a big improvement.  It makes Phases more testable, with less use of temporary directories to handle save and then to examine results.  

It also allows a custom Pipeline to override load/save for all phases, so it could do something other than local file storage entirely.  

This doesn't complete the work we'd planned for extra inputs as well as extra outputs, and having the Pipeline be able to marshall inputs/outputs between phases - there's still a simple chain of phase(n) -> output == input -> phase(n+1).
