### PR TITLE
Prevents DropRowException from being thrown in batch steps, fix error hierarchy

### DIFF
--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -27,7 +27,8 @@ have datatype casting and name canonicalization done automatically.
 # commitment to build for that.
 
 
-from phaser.pipeline import Pipeline, PipelineErrorException, PhaserException, DropRowException, WarningException
+from phaser.pipeline import (Pipeline, PhaserError,
+                             PipelineErrorException, PhaserException, DropRowException, WarningException)
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
 from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -49,7 +49,10 @@ class PhaseBase(ABC):
         :param row: What row of the data this occurred in
         :return: Nothing
         """
-        if isinstance(exc, DropRowException):
+        if isinstance(exc, PhaserError):
+            # PhaserError is raised in case of coding contract issues, so should bypass data exception handling.
+            raise exc
+        elif isinstance(exc, DropRowException):
             self.context.add_dropped_row(step, row, exc.message)
         elif isinstance(exc, WarningException):
             self.context.add_warning(step, row, exc.message)
@@ -333,9 +336,6 @@ class Phase(PhaseBase):
             elif row_size_diff < 0:
                 self.context.add_warning(step, None, f"{abs(row_size_diff)} rows were ADDED by step")
             self.row_data = PhaseRecords([row for row in new_row_values])
-        except PhaserError as e:
-            # A coding error should bypass the data exception handling
-            raise e
         except Exception as exc:
             self.process_exception(exc, step, None)
 

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -11,6 +11,8 @@ logger.addHandler(logging.NullHandler())
 
 
 class PhaserException(Exception):
+    """ PhaserException is thrown when processing data, and to trigger the library code to do something
+    about that data."""
 
     def __init__(self, message):
         self.message = message
@@ -35,6 +37,18 @@ class WarningException(PhaserException):
     in methods where a return value is needed, it can be used in methods that check results without returning
     fixed data.  """
     pass
+
+
+class PhaserError(Exception):
+    """ PhaserError indicates not a data issue to handle in processing, but a coding error in phaser
+    or in client code that does not meet the interface contract.  Example: in order to avoid
+    accidentally dropping rows, a row step must return a row or throw an exception.  If a row
+    step returns none, the phaser library raises PhaserError to report this to the developer."""
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
 
 
 def _stringify_step(step):

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -50,6 +50,9 @@ def context_step(step_function):
         if __probe__ == PROBE_VALUE:
             return CONTEXT_STEP
         result = step_function(context)
+        if result is not None:
+            raise PhaserError(f"Context steps are not expected to return a value (step is {step_function})")
+
     return _context_step_wrapper
 
 
@@ -68,7 +71,7 @@ def check_unique(column, strip=True, ignore_case=False):
     column_name = column.name if isinstance(column, Column) else column
 
     @batch_step
-    def check_unique_step(batch, context):
+    def check_unique_step(batch, *args):
         try:
             values = [row[column_name] for row in batch]
         except KeyError:

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from functools import wraps
-from .pipeline import PipelineErrorException, PhaserException
+from .pipeline import PipelineErrorException, PhaserException, DropRowException, PhaserError
 from .column import Column
 
 ROW_STEP = "ROW_STEP"
@@ -33,9 +33,12 @@ def batch_step(step_function):
     def _batch_step_wrapper(batch, context=None, __probe__=None):
         if __probe__ == PROBE_VALUE:
             return BATCH_STEP
-        result = step_function(batch, context=context)
+        try:
+            result = step_function(batch, context=context)
+        except DropRowException as exc:
+            raise PhaserError("DropRowException can't be handled in batch steps ") from exc
         if not isinstance(result, Sequence):
-            raise PipelineErrorException(
+            raise PhaserError(
                 f"Step {step_function} returned a {result.__class__} rather than a list of rows")
         return result
     return _batch_step_wrapper

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -24,6 +24,7 @@ def check_room_is_hologram_room(row, context):
 def warn_if_lower_decks(row, context):
     if int(row['deck']) < 10:
         raise WarningException("Lower decks should not be in this dataset")
+    return row
 
 
 @row_step

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -135,3 +135,14 @@ def test_context_step_cant_raise_drop_row():
     with pytest.raises(PhaserError) as exc_info:
         phase.run_steps()
     assert "DropRowException can't" in exc_info.value.message
+
+def test_context_step_cant_return_random_stuff():
+    @context_step
+    def return_inappropriate_stuff(context):
+        return {'message': 'what is the pipeline even supposed to do with this'}
+
+    phase = Phase(steps=[return_inappropriate_stuff])
+    phase.load_data([{}])
+    with pytest.raises(PhaserError) as exc_info:
+        phase.run_steps()
+    assert "return a value" in exc_info.value.message


### PR DESCRIPTION
Adds a check in batch step handling to make sure that client code didn't throw DropRowException.  

Also adds a new kind of Exception to handle coding errors (please fix client codeare completely separate from data error/warning/drop aggregation and handling.

What do you think of renaming the Exceptions slightly?

*     DataException.   (was: PhaserException)
     --> WarningException. (same)
     --> DropRowException.  (same) 
     --> DataErrorException.   (was: PipelineErrorException)
*     PhaserError.   (new)

