### PR TITLE
Moves error reporting to the Pipeline, which allows separation of issues by Phase

### DIFF
--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -28,7 +28,7 @@ have datatype casting and name canonicalization done automatically.
 
 
 from phaser.pipeline import (Pipeline, PhaserError,
-                             PipelineErrorException, PhaserException, DropRowException, WarningException)
+                             DataErrorException, DataException, DropRowException, WarningException)
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
 from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn

--- a/phaser/column.py
+++ b/phaser/column.py
@@ -6,7 +6,7 @@ import logging
 import types
 from collections.abc import Iterable
 from pandas import isna
-from .pipeline import DropRowException, PipelineErrorException, WarningException
+from .pipeline import DropRowException, DataErrorException, WarningException
 
 logger = logging.getLogger('phaser')
 
@@ -69,14 +69,14 @@ class Column:
             self.rename = [self.rename]
         self.allowed_values = allowed_values
         self.save = save
-        self.use_exception = PipelineErrorException
+        self.use_exception = DataErrorException
         if on_error:
             self.use_exception = {
                 'warn': WarningException,
                 'drop_row': DropRowException,
-                'collect': PipelineErrorException,
+                'collect': DataErrorException,
                 'stop_now': Exception
-            }.get(on_error, PipelineErrorException)
+            }.get(on_error, DataErrorException)
 
         if self.null is False and self.default is not None:
             raise Exception(f"Column {self.name} defined to error on null values, but also provides a non-null default")

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -353,6 +353,7 @@ class Phase(PhaseBase):
 
 
 class PhaseRecords(UserList):
+    """ PhaseRecords holds the records or rows loaded into a phase, together with row numbers (indexed from 1) """
     def __init__(self, *args):
         super().__init__(*args)
         # Slicing a UserList results in constructing a brand new list, which
@@ -362,7 +363,7 @@ class PhaseRecords(UserList):
         # This is also generally helpful in steps where the record is mutated
         # and returned rather than being constructed new.
         self.data = [
-            PhaseRecords._recordize(index, record)
+            PhaseRecords._recordize(index+1, record)
             for index, record in enumerate(self.data)
         ]
 

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -1,6 +1,6 @@
 from collections.abc import Mapping, Sequence
 from functools import wraps
-from .pipeline import PipelineErrorException, PhaserException, DropRowException, PhaserError
+from .pipeline import DataErrorException, DataException, DropRowException, PhaserError
 from .column import Column
 
 ROW_STEP = "ROW_STEP"
@@ -18,9 +18,9 @@ def row_step(step_function):
             return ROW_STEP  # Allows Phase to probe a step for how to call it
         result = step_function(row, context=context)
         if result is None:
-            raise PipelineErrorException("Step should return row.")
+            raise PhaserError("Step should return row.")
         if not isinstance(result, Mapping):
-            raise PipelineErrorException(f"Step should return row in dict format, not {result}")
+            raise PhaserError(f"Step should return row in dict format, not {result}")
         return result
     return _row_step_wrapper
 
@@ -75,13 +75,13 @@ def check_unique(column, strip=True, ignore_case=False):
         try:
             values = [row[column_name] for row in batch]
         except KeyError:
-            raise PipelineErrorException(f"Check_unique: Some or all rows did not have '{column_name}' present")
+            raise DataErrorException(f"Check_unique: Some or all rows did not have '{column_name}' present")
         if strip:
             values = [safe_strip(value) for value in values]
         if ignore_case:
             values = [value.lower() for value in values]
         if len(set(values)) != len(values):
-            raise PipelineErrorException(f"Some values in {column_name} were duplicated, so unique check failed")
+            raise DataErrorException(f"Some values in {column_name} were duplicated, so unique check failed")
         return batch
 
     return check_unique_step
@@ -98,7 +98,7 @@ def sort_by(column):
     elif isinstance(column, str):
         column_name = column
     else:
-        raise PhaserException("Error declaring sort_by step - expecting column to be a Column or a column name string")
+        raise PhaserError("Error declaring sort_by step - expecting column to be a Column or a column name string")
 
     @batch_step
     def sort_by_step(batch, **kwargs):

--- a/tests/pipelines/employees.py
+++ b/tests/pipelines/employees.py
@@ -13,7 +13,7 @@ exact decimal versions
 
 """
 from phaser import (Phase, Pipeline, Column, FloatColumn, row_step, check_unique,
-                    PipelineErrorException, DropRowException)
+                    DataErrorException, DropRowException)
 
 
 """
@@ -31,11 +31,11 @@ import employee data fixture  (change the other tests to use a 'crew' fixture)
 def drop_rows_with_no_id_and_not_employed(row, **kwargs):
     if not row["Employee ID"]:
         if row['Status'] == "Active":
-            raise PipelineErrorException("Missing employee ID for active employee, need to followup")
+            raise DataErrorException("Missing employee ID for active employee, need to followup")
         elif row['Status'] == "Inactive":
             raise DropRowException(f"Employee {row['Last name']} has no ID and inactive, dropping row")
         else:
-            raise PipelineErrorException(f"Unknown employee status {row['Status']}")
+            raise DataErrorException(f"Unknown employee status {row['Status']}")
     return row
 
 

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -1,6 +1,6 @@
 import pandas as pd
 
-from phaser import Phase, row_step, Pipeline, Column, IntColumn, read_csv, PipelineErrorException
+from phaser import Phase, row_step, Pipeline, Column, IntColumn, read_csv, DataException
 import pytest  # noqa # pylint: disable=unused-import
 import os
 from pathlib import Path
@@ -137,6 +137,6 @@ def test_phase_saved_even_if_error(tmpdir):
         f.write('crew member,level\n"B\'Elanna Torres",-1\n')
     pipeline = Pipeline(tmpdir, tmpdir / 'negative-level.csv', phases=[phase])
     pipeline.setup_phases()
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataException):
         pipeline.run_phase(phase, tmpdir / 'negative-level.csv', tmpdir / 'test-saved-despite-error.csv')
     assert os.path.exists(os.path.join(tmpdir, 'test-saved-despite-error.csv'))

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -5,7 +5,7 @@ import pytest
 from dateutil.tz import gettz
 
 from phaser import (Phase, Column, IntColumn, FloatColumn, DateColumn, DateTimeColumn,
-                    PipelineErrorException, DropRowException)
+                    DataErrorException, DropRowException)
 
 
 # Constructor tests
@@ -16,7 +16,7 @@ def test_null_forbidden_but_null_default():
 
 def test_invalid_on_error():
     col = Column(name="anything", on_error="Bogus")
-    assert col.use_exception == PipelineErrorException
+    assert col.use_exception == DataErrorException
 
 
 # Simple feature tests
@@ -24,13 +24,13 @@ def test_invalid_on_error():
 def test_required_values():
     mycol = Column('crew', allowed_values=["Kirk", "Riker", "Troi", "Crusher"])
     mycol.check_and_cast_value({"crew": "Kirk", 'position': "Captain"})
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         mycol.check_and_cast_value({"crew": "Gilligan", 'position': "mate"})
 
 
 def test_null_forbidden():
     col = Column('employeeid', null=False)
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         col.check_and_cast_value({'employeeid': None})
 
 
@@ -154,9 +154,9 @@ def test_cast_when_not_present():
 
 def test_int_column_minmax():
     col = IntColumn(name="Age", min_value=0, max_value=130)
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         col.check_value(-1)
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         col.check_value(2000)
 
 
@@ -196,7 +196,7 @@ def test_date_column_casts_to_date():
 def test_date_column_range():
     col = DateColumn(name="start", min_value=date(2019, 12, 1), max_value=date.today())
     col.check_and_cast_value({'start': "2024-01-14"})
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         col.check_and_cast_value({'start': "2012-01-01"})
 
 

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -23,4 +23,4 @@ def test_results(tmpdir):
     assert all([row['Bonus percent'] > 0.1 and row['Bonus percent'] < 0.2 for row in new_data])
 
     assert len(pipeline.context.dropped_rows) == 1
-    assert "Garak" in pipeline.context.dropped_rows[2]['message']
+    assert "Garak" in pipeline.context.dropped_rows[3]['message']

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -135,4 +135,4 @@ def test_row_error_formatting():
     phase.load_data([{'deck': '21'}])
 
     phase.run_steps()
-    phase.report_errors_and_warnings()
+    # phase.report_errors_and_warnings()  Errors and warning reporting moved to pipeline

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -62,8 +62,8 @@ def test_error_provides_info(reconcile_phase_class):
     phase.load_data([{'deck': '21'}])
 
     phase.run_steps()
-    error = phase.context.errors[0]
-    assert error['row'].row_num == 0
+    error = phase.context.errors[1]
+    assert error['row'].row_num == 1
     assert error['row']['deck'] == '21'
     assert error['step'] == 'assert_false'
     assert error['message'] == "AssertionError raised (assert False)"
@@ -77,8 +77,8 @@ def test_row_processing_continues():
 
     phase.run_steps()
     assert len(phase.context.errors) == 2
-    assert phase.context.errors[0]['step'] == 'check_deck_is_21'   # First row fails on the first step
-    assert phase.context.errors[1]['step'] == 'assert_false'  # 2nd row fails on 2nd step
+    assert phase.context.errors[1]['step'] == 'check_deck_is_21'   # First row fails on the first step
+    assert phase.context.errors[2]['step'] == 'assert_false'  # 2nd row fails on 2nd step
 
 
 def test_row_processing_skips_row():
@@ -89,7 +89,7 @@ def test_row_processing_skips_row():
 
     phase.run_steps()
     assert len(phase.context.errors) == 1
-    assert phase.context.errors[0]['step'] == 'check_deck_is_21'
+    assert phase.context.errors[1]['step'] == 'check_deck_is_21'
 
 
 def test_warning_contains_info():
@@ -98,7 +98,7 @@ def test_warning_contains_info():
 
     phase.run_steps()
     assert len(phase.context.warnings) == 1
-    the_warning = phase.context.warnings[1][0]
+    the_warning = phase.context.warnings[2][0]
     assert the_warning['row']['deck'] == '5'
     assert the_warning['step'] == 'warn_if_lower_decks'
     assert the_warning['message'] == "Lower decks should not be in this dataset"
@@ -110,7 +110,7 @@ def test_drop_row_info():
 
     phase.run_steps()
     assert len(phase.context.dropped_rows) == 1
-    assert phase.context.dropped_rows[1]['step'] == 'check_deck_is_21'
+    assert phase.context.dropped_rows[2]['step'] == 'check_deck_is_21'
 
 
 def test_batch_step_error():

--- a/tests/test_record_metadata.py
+++ b/tests/test_record_metadata.py
@@ -44,7 +44,6 @@ def test_row_step_preserves_row_nums(steps, expected_row_nums):
     phase = Phase(steps=steps)
     phase.load_data(data)
     phase.run_steps()
-    phase.report_errors_and_warnings()
     row_data = phase.row_data
     row_nums = [ r.row_num for r in row_data ]
     assert row_nums == expected_row_nums
@@ -93,7 +92,6 @@ def test_batch_step_preserves_row_num(steps, expected_row_nums):
     phase = Phase(steps=steps)
     phase.load_data(data)
     phase.run_steps()
-    phase.report_errors_and_warnings()
     row_data = phase.row_data
     row_nums = [ r.row_num for r in row_data ]
     assert row_nums == expected_row_nums

--- a/tests/test_record_metadata.py
+++ b/tests/test_record_metadata.py
@@ -8,15 +8,15 @@ def futz_with_row_num(row, **kwargs):
     return row
 
 @row_step
-def error_on_row_three(row, **kwargs):
-    if row.row_num == 3:
-        raise WarningException("Row three warning!")
+def error_on_row_four(row, **kwargs):
+    if row.row_num == 4:
+        raise WarningException("Row four warning!")
     return row
 
 @row_step
-def drop_row_four(row, **kwargs):
-    if row.row_num == 4:
-        raise DropRowException("Row four dropped!")
+def drop_row_five(row, **kwargs):
+    if row.row_num == 5:
+        raise DropRowException("Row five dropped!")
     return row
 
 @row_step
@@ -25,21 +25,21 @@ def return_native_dict(row, **kwargs):
 
 @pytest.mark.parametrize("steps, expected_row_nums",
     [
-        ([futz_with_row_num], [0, 1, 2, 3, 4, 5]),
-        ([error_on_row_three], [0, 1, 2, 3, 4, 5]),
-        ([drop_row_four], [0, 1, 2, 3, 5]),
-        ([error_on_row_three, drop_row_four], [0, 1, 2, 3, 5]),
-        ([return_native_dict], [0, 1, 2, 3, 4, 5]),
+        ([futz_with_row_num], [1, 2, 3, 4, 5, 6]),
+        ([error_on_row_four], [1, 2, 3, 4, 5, 6]),
+        ([drop_row_five], [1, 2, 3, 4, 6]),
+        ([error_on_row_four, drop_row_five], [1, 2, 3, 4, 6]),
+        ([return_native_dict], [1, 2, 3, 4, 5, 6]),
     ]
 )
 def test_row_step_preserves_row_nums(steps, expected_row_nums):
     data = [
-        { 'row': 0, 'num': 'zero'},
-        { 'row': 1, 'num': 'one'},
-        { 'row': 2, 'num': 'two'},
-        { 'row': 3, 'num': 'three'},
-        { 'row': 4, 'num': 'four'},
-        { 'row': 5, 'num': 'five'},
+        { 'row': 1, 'num': 'zero'},
+        { 'row': 2, 'num': 'one'},
+        { 'row': 3, 'num': 'two'},
+        { 'row': 4, 'num': 'three'},
+        { 'row': 5, 'num': 'four'},
+        { 'row': 6, 'num': 'five'},
     ]
     phase = Phase(steps=steps)
     phase.load_data(data)
@@ -50,7 +50,7 @@ def test_row_step_preserves_row_nums(steps, expected_row_nums):
     assert row_nums == expected_row_nums
 
 @batch_step
-def remove_odd_rows(batch, **kwargs):
+def remove_even_rows(batch, **kwargs):
     return [ row for index, row in enumerate(batch) if index % 2 == 0 ]
 
 @batch_step
@@ -76,19 +76,19 @@ def accidentally_resets_row_nums(batch, **kwargs):
 
 @pytest.mark.parametrize("steps, expected_row_nums",
     [
-        ([remove_odd_rows], [0, 2, 4]),
-        ([sum_a_column], [0, 3, 4]),
-        ([accidentally_resets_row_nums], [0, 1, 2]),
+        ([remove_even_rows], [1, 3, 5]),
+        ([sum_a_column], [1, 4, 5]),
+        ([accidentally_resets_row_nums], [1, 2, 3]),
     ]
 )
 def test_batch_step_preserves_row_num(steps, expected_row_nums):
     data = [
-        { 'row': 0, 'id': 10, 'num': 'zero', 'n': 10 },
-        { 'row': 1, 'id': 10, 'num': 'one', 'n': 15 },
-        { 'row': 2, 'id': 10, 'num': 'two', 'n': 20 },
-        { 'row': 3, 'id': 11, 'num': 'three', 'n': 10 },
-        { 'row': 4, 'id': 12, 'num': 'four', 'n': 10 },
-        { 'row': 5, 'id': 12, 'num': 'five', 'n': 15 },
+        { 'row': 1, 'id': 10, 'num': 'zero', 'n': 10 },
+        { 'row': 2, 'id': 10, 'num': 'one', 'n': 15 },
+        { 'row': 3, 'id': 10, 'num': 'two', 'n': 20 },
+        { 'row': 4, 'id': 11, 'num': 'three', 'n': 10 },
+        { 'row': 5, 'id': 12, 'num': 'four', 'n': 10 },
+        { 'row': 6, 'id': 12, 'num': 'five', 'n': 15 },
     ]
     phase = Phase(steps=steps)
     phase.load_data(data)

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -2,7 +2,7 @@ from pathlib import Path
 import pytest
 
 from phaser import (check_unique, Phase, row_step, batch_step, context_step, Pipeline, sort_by, IntColumn,
-                    PipelineErrorException, DropRowException, PhaserError, read_csv)
+                    DataErrorException, DropRowException, PhaserError, read_csv)
 from fixtures import test_data_phase_class
 
 current_path = Path(__file__).parent
@@ -45,13 +45,13 @@ def test_builtin_step():
 def test_check_unique_fails(test_data_phase_class):
     phase = test_data_phase_class(error_policy=Pipeline.ON_ERROR_STOP_NOW)
     phase.load_data([{'id': '1'}, {'id': '1'}])
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         phase.run_steps()
 
 
 def test_check_unique_strips_spaces():
     fn = check_unique('id')
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         fn([{'id': " 1 "}, {'id': '1'}])
 
 
@@ -67,7 +67,7 @@ def test_check_unique_case_sensitive():
 
 def test_check_unique_case_insensitive():
     fn = check_unique('dept', ignore_case=True)
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         fn([{'dept': "ENG"}, {'dept': 'Sales'}, {'dept': "Eng"}])
 
 
@@ -79,7 +79,7 @@ def test_check_unique_null_values():
 def test_check_unique_int_values():
     fn = check_unique('id')
     fn([{'id': 1}, {'id': 2}, {'id': 3}])   # passes
-    with pytest.raises(PipelineErrorException):
+    with pytest.raises(DataErrorException):
         fn([{'id': 1}, {'id': 2}, {'id': 2}])
 
 
@@ -91,7 +91,7 @@ def test_check_unique_takes_column_instance():
 
 def test_check_unique_is_helpful_when_column_missing():
     fn = check_unique('crew id')
-    with pytest.raises(PipelineErrorException) as error_info:
+    with pytest.raises(DataErrorException) as error_info:
         fn([{'id': 1}, {'id': 2}, {'id': 3}])
     assert "Check_unique: Some or all rows did not have 'crew id' present" in error_info.value.message
 


### PR DESCRIPTION
We probably want to do more with error reporting in the Pipeline
- we want to save it out to disk
- we want to make all event reporting programmatically available to whatever is calling the Pipeline in automation
- thus we probably want to save all the errors at some point

We may even want to refactor to save the errors ON the phase instead of on the context - the Pipeline can pull the results off the phase - but I still think the choice of output (stdout, disk, etc) belongs in pipeline so even if we refactor I think that part will stay in Pipeline