### PR TITLE
Move exceptions to their own file in preparation to avoid circular imports

### DIFF
--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -27,8 +27,8 @@ have datatype casting and name canonicalization done automatically.
 # commitment to build for that.
 
 
-from phaser.pipeline import (Pipeline, PhaserError,
-                             DataErrorException, DataException, DropRowException, WarningException)
+from phaser.pipeline import Pipeline
+from phaser.exceptions import PhaserError, DataErrorException, DataException, DropRowException, WarningException
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
 from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn

--- a/phaser/exceptions.py
+++ b/phaser/exceptions.py
@@ -1,0 +1,43 @@
+
+class DataException(Exception):
+    """ DataException subclasses are thrown when processing data, to trigger the phaser library code to follow
+     error-handling policy, often with respect to the row the issue occurs in."""
+
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+
+
+class DataErrorException(DataException):
+    """ Using this exception will cause the data or the specific row to be listed among errors.
+    If possible, the pipeline will keep going to the end of a phase, collecting more errors, so they can all
+    be dealt with.  """
+    pass
+
+
+class DropRowException(DataException):
+    """ Throwing this exception in a row_step will cause the current row to be dropped. Rows dropped this
+    way will be listed in the phase results report along with a reason given in the exception constructor. """
+    pass
+
+
+class WarningException(DataException):
+    """ Throwing this exception will add warnings to the output of the pipeline.  While it can't be used
+    in methods where a return value is needed, it can be used in methods that check results without returning
+    fixed data.  """
+    pass
+
+
+class PhaserError(Exception):
+    """ PhaserError indicates not a data issue to handle in processing, but a coding error in phaser
+    or in client code that does not meet the interface contract.  Example: in order to avoid
+    accidentally dropping rows, a row step must return a row or throw an exception.  If a row
+    step returns none, the phaser library raises PhaserError to report this to the developer."""
+    def __init__(self, message):
+        self.message = message
+
+    def __str__(self):
+        return self.message
+

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -4,53 +4,11 @@ import os
 import pandas as pd
 import phaser
 from phaser.util import read_csv
+from phaser.exceptions import *
 from pathlib import PosixPath
 
 logger = logging.getLogger('phaser')
 logger.addHandler(logging.NullHandler())
-
-
-class DataException(Exception):
-    """ DataException subclasses are thrown when processing data, to trigger the phaser library code to follow
-     error-handling policy, often with respect to the row the issue occurs in."""
-
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return self.message
-
-
-class DataErrorException(DataException):
-    """ Using this exception will cause the data or the specific row to be listed among errors.
-    If possible, the pipeline will keep going to the end of a phase, collecting more errors, so they can all
-    be dealt with.  """
-    pass
-
-
-class DropRowException(DataException):
-    """ Throwing this exception in a row_step will cause the current row to be dropped. Rows dropped this
-    way will be listed in the phase results report along with a reason given in the exception constructor. """
-    pass
-
-
-class WarningException(DataException):
-    """ Throwing this exception will add warnings to the output of the pipeline.  While it can't be used
-    in methods where a return value is needed, it can be used in methods that check results without returning
-    fixed data.  """
-    pass
-
-
-class PhaserError(Exception):
-    """ PhaserError indicates not a data issue to handle in processing, but a coding error in phaser
-    or in client code that does not meet the interface contract.  Example: in order to avoid
-    accidentally dropping rows, a row step must return a row or throw an exception.  If a row
-    step returns none, the phaser library raises PhaserError to report this to the developer."""
-    def __init__(self, message):
-        self.message = message
-
-    def __str__(self):
-        return self.message
 
 
 def _stringify_step(step):


### PR DESCRIPTION

e.g. when I tried to import exceptions into util, and a util into Pipeline.py, it made a circular import and failed