### PR TITLE
Use clevercsv

### DIFF
--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -32,6 +32,6 @@ from phaser.exceptions import PhaserError, DataErrorException, DataException, Dr
 from phaser.phase import Phase, ReshapePhase, DataFramePhase
 from phaser.steps import row_step, batch_step, context_step, check_unique, sort_by
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn
-from phaser.util import read_csv
+from phaser.io import read_csv
 
 __version__ = 0.1

--- a/phaser/io.py
+++ b/phaser/io.py
@@ -1,8 +1,10 @@
 from clevercsv import stream_dicts, stream_table
-from .exceptions import DataErrorException
+from phaser.exceptions import DataErrorException
 
 
 def read_csv(source):
+    # Using the 'stream_table' method we can get just the header row, and perform our check for
+    # duplicate columns before having the library parse everything into dicts.
     stream = stream_table(source)
     header = next(stream)
     if len(header) > len(set(header)):

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -233,6 +233,8 @@ class Phase(PhaseBase):
 
         def rename_me(name):
             name = name.strip()
+            if name.startswith('"') and name.endswith('"'):
+                name = name.strip('"')
             if make_strict_name(name) in strict_name_list.keys():
                 name = strict_name_list[make_strict_name(name)]  # Convert to declared capital'n/separ'n
             if name in rename_list.keys():

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -3,7 +3,7 @@ import logging
 import os
 import pandas as pd
 import phaser
-from phaser.util import read_csv
+from phaser.io import read_csv
 from phaser.exceptions import *
 from pathlib import PosixPath
 from phaser.exceptions import *

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -6,6 +6,7 @@ import phaser
 from phaser.util import read_csv
 from phaser.exceptions import *
 from pathlib import PosixPath
+from phaser.exceptions import *
 
 logger = logging.getLogger('phaser')
 logger.addHandler(logging.NullHandler())
@@ -138,7 +139,7 @@ class Pipeline:
 
     def run_phase(self, phase, source, destination):
         logger.info(f"Loading input from {source} for {phase.name}")
-        data = self.load(phase, source)
+        data = self.load(source)
         phase.load_data(data)
         results = phase.run()
         self.save(results, destination)
@@ -177,15 +178,10 @@ class Pipeline:
                 logger.info(f"Extra output {item.name} saved to {self.working_dir}")
                 item.to_save = False
 
-    def load(self, phase, next_source):
+    def load(self, source):
         """ The load method can be overridden to apply a pipeline-specific way of loading data.
         Phaser default is to read data from a CSV file. """
-        df = read_csv(next_source)
-        # This is a hacky way to handle a phase we know needs a DataFrame as its
-        # data, rather than a list of dicts.
-        if isinstance(phase, phaser.DataFramePhase):
-            return df
-        return df.to_dict('records')
+        return read_csv(source)
 
     def save(self, results, destination):
         """ This method saves the result of the Phase operating on the batch, in phaser's preferred format.

--- a/phaser/util.py
+++ b/phaser/util.py
@@ -1,22 +1,11 @@
-import pandas as pd
+import clevercsv
+from .exceptions import DataErrorException
 
 
 def read_csv(source):
-    """ Includes the default settings phaser uses with panda's read_csv. Can be overridden to provide
-    different read_csv settings.
-    Defaults:
-    * assume all column values are strings, so leading zeros or trailing zeros don't get destroyed.
-    * assume ',' value-delimiter
-    * skip_blank_lines=True: allows blank AND '#'-led rows to be skipped and still find header row
-    * doesn't use indexing
-    * does attempt to decompress common compression formats if file uses them
-    * assume UTF-8 encoding
-    * uses '#' as the leading character to assume a row is comment
-    * Raises errors loading 'bad lines', rather than skip
-    """
-    return pd.read_csv(source,
-                       dtype='str',
-                       sep=',',
-                       skip_blank_lines=True,
-                       index_col=False,
-                       comment='#')
+    stream = clevercsv.stream_table(source)
+    header = next(stream)
+    if len(header) > len(set(header)):
+        raise DataErrorException(f"CSV {source} has duplicate column names and cannot reliably be parsed")
+
+    return clevercsv.read_dicts(source)

--- a/phaser/util.py
+++ b/phaser/util.py
@@ -1,11 +1,11 @@
-import clevercsv
+from clevercsv import stream_dicts, stream_table
 from .exceptions import DataErrorException
 
 
 def read_csv(source):
-    stream = clevercsv.stream_table(source)
+    stream = stream_table(source)
     header = next(stream)
     if len(header) > len(set(header)):
         raise DataErrorException(f"CSV {source} has duplicate column names and cannot reliably be parsed")
 
-    return clevercsv.read_dicts(source)
+    return list(stream_dicts(source))

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -71,7 +71,7 @@ def full_name_step(row, **kwargs):
 
 # Phase tests
 
-def phase_accepts_single_col():
+def test_phase_accepts_single_col():
     # Helpfully should wrap column in a list if only one is defined
     col = Column(name="Test")
     phase = Phase(name="Transform", columns=col)
@@ -84,28 +84,6 @@ def test_have_and_run_steps(tmpdir):
     transformer.load_data(read_csv(current_path / "fixture_files" / "crew.csv"))
     transformer.run_steps()
     assert "full name" in transformer.row_data[1]
-
-
-def test_duplicate_column_names(tmpdir):
-    with open(tmpdir / 'dupe-column-name.csv', 'w') as f:
-        f.write("id,name,name\n1,Percy,Jackson\n")
-    pipeline = Pipeline(working_dir=tmpdir, source=tmpdir / 'dupe-column-name.csv')
-    with pytest.raises(Exception):
-        pipeline.load(tmpdir / 'dupe-column-name.csv')
-
-
-def test_extra_field_in_csv(tmpdir):
-    with open(tmpdir / 'extra-field.csv', 'w') as f:
-        f.write("id,name,age\n1,James Kirk,42,\n")
-    pipeline = Pipeline(working_dir=tmpdir, source=tmpdir / 'extra-field.csv')
-    data = pipeline.load(tmpdir / 'extra-field.csv')
-    phase = Phase()
-    phase.load_data(data)
-    phase.do_column_stuff()
-
-    assert len(phase.context.warnings) == 1
-    print(phase.context.warnings)
-    assert 'Extra value found' in phase.context.warnings[1][0]['message']
 
 
 def test_column_error_drops_row():

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -124,6 +124,25 @@ def test_forbidden_column_name_characters():
         Column('a\tb\tc')
 
 
+def test_strip_column_name_spaces(tmpdir):
+    phase = Phase()
+    phase.load_data([{' id': '1', ' name': 'James T. Kirk'}])
+    phase.rename_columns()
+    assert phase.row_data[0]['id'] == '1'
+
+
+def test_curious_quote_situation(tmpdir):
+    """ If we load column names in with clevercsv or pandas, column names in quotes get the quotes removed
+     so "id","name" loads in the names you'd expect.  However, we can't count on that working if there are ALSO
+     spaces around column names - which normal people quite normally add when they're trying to 'fix' a CSV.
+     This test provides what the libraries provide after opening a CSV where the opening line is
+         "id", "name"\n
+     to make sure that our code strips the spaces AND quotes."""
+    phase = Phase()
+    phase.load_data([{'id': '1', ' "name"': 'James T. Kirk'}])
+    phase.rename_columns()
+    assert phase.row_data[0]['name'] == 'James T. Kirk'
+
 # Testing IntColumn
 
 def test_int_column_casts():

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,6 +1,6 @@
 import pytest
 from phaser import Pipeline, Phase, DataErrorException
-from phaser.util import read_csv
+from phaser.io import read_csv
 
 def test_duplicate_column_names(tmpdir):
     with open(tmpdir / 'dupe-column-name.csv', 'w') as f:

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,12 +1,12 @@
 import pytest
-from phaser import Pipeline, Phase
+from phaser import Pipeline, Phase, DataErrorException
 from phaser.util import read_csv
 
 def test_duplicate_column_names(tmpdir):
     with open(tmpdir / 'dupe-column-name.csv', 'w') as f:
         f.write("id,name,name\n1,Percy,Jackson\n")
     pipeline = Pipeline(working_dir=tmpdir, source=tmpdir / 'dupe-column-name.csv')
-    with pytest.raises(Exception):
+    with pytest.raises(DataErrorException):
         pipeline.load(tmpdir / 'dupe-column-name.csv')
 
 
@@ -24,22 +24,54 @@ def test_extra_field_in_csv(tmpdir):
     assert 'Extra value found' in phase.context.warnings[1][0]['message']
 
 
+@pytest.mark.skip("It would be nice to identify rows with not enough fields...")
+def test_not_enough_fields_in_csv(tmpdir):
+    with open(tmpdir / 'insufficient-field.csv', 'w') as f:
+        f.write("id,name,age\n1,James Kirk\n")
+    pipeline = Pipeline(working_dir=tmpdir, source=tmpdir / 'insufficient-field.csv')
+    data = pipeline.load(tmpdir / 'insufficient-field.csv')
+    phase = Phase()
+    phase.load_data(data)
+    phase.do_column_stuff()
+
+    assert len(phase.context.warnings) == 1
+
+
+@pytest.mark.skip("Commented lines are really hard to skip with clevercsv but otherwise it's a good library...")
 def test_comment_lines(tmpdir):
-    # TODO assuming we write code to make this work - parametrize comments on different lines
     with open(tmpdir / 'commented_line', 'w') as f:
         f.write("#crew\n,id,name\n,1,James Kirk\n")
     assert read_csv(tmpdir / 'commented_line') == [{'id':1, 'name':'James Kirk'}]
 
 
-def test_empty_lines(tmpdir):
-    # TODO assuming we write code to make this work - parametrize empty lines in different places
+def test_empty_lines_at_end(tmpdir):
     with open(tmpdir / 'commented_line', 'w') as f:
-        f.write("\nid,name\n,1,James Kirk\n")
-    assert read_csv(tmpdir / 'commented_line') == [{'id':1, 'name':'James Kirk'}]
+        f.write("id,name\n1,James Kirk\n\n\n")
+    assert dict(read_csv(tmpdir / 'commented_line')[0]) == {'id':'1', 'name':'James Kirk'}
 
 
-def test_strip_spaces(tmpdir):
-    # TODO assuming we write code to make this work - test stripping from values as well as headers
-    with open(tmpdir / 'extra_spaces', 'w') as f:
-        f.write("  id,name\n,1,James Kirk\n")
-    assert read_csv(tmpdir / 'extra_spaces') == [{'id':1, 'name':'James Kirk'}]
+def test_empty_lines_elsewhere(tmpdir):
+    with open(tmpdir / 'commented_line', 'w') as f:
+        f.write("id,name\n\n1,James Kirk\n")
+    assert dict(read_csv(tmpdir / 'commented_line')[0]) == {'id':'1', 'name':'James Kirk'}
+
+
+@pytest.mark.skip("An empty line at the beginning of the file doesn't work. I think we can live with that")
+def test_empty_line_at_beginning(tmpdir):
+    with open(tmpdir / 'commented_line', 'w') as f:
+        f.write("\nid,name\n1,James Kirk\n")
+    assert dict(read_csv(tmpdir / 'commented_line')[0]) == {'id':'1', 'name':'James Kirk'}
+
+
+def test_regular_quotes(tmpdir):
+    with open(tmpdir / 'commented_line', 'w') as f:
+        f.write('"id","name"\n1,James Kirk\n')
+    assert dict(read_csv(tmpdir / 'commented_line')[0])== {'id': '1', 'name': 'James Kirk'}
+
+
+@pytest.mark.skip("Although the library removes quotes normally, a space makes that not happen")
+def test_curious_quote_situation(tmpdir):
+    """ It's OK though, we can strip spaces and quotes when we canonicalize column names """
+    with open(tmpdir / 'commented_line', 'w') as f:
+        f.write('"id", "name"\n1,James Kirk\n')
+    assert dict(read_csv(tmpdir / 'commented_line')[0])== {'id': '1', 'name': 'James Kirk'}

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -1,0 +1,45 @@
+import pytest
+from phaser import Pipeline, Phase
+from phaser.util import read_csv
+
+def test_duplicate_column_names(tmpdir):
+    with open(tmpdir / 'dupe-column-name.csv', 'w') as f:
+        f.write("id,name,name\n1,Percy,Jackson\n")
+    pipeline = Pipeline(working_dir=tmpdir, source=tmpdir / 'dupe-column-name.csv')
+    with pytest.raises(Exception):
+        pipeline.load(tmpdir / 'dupe-column-name.csv')
+
+
+def test_extra_field_in_csv(tmpdir):
+    with open(tmpdir / 'extra-field.csv', 'w') as f:
+        f.write("id,name,age\n1,James Kirk,42,\n")
+    pipeline = Pipeline(working_dir=tmpdir, source=tmpdir / 'extra-field.csv')
+    data = pipeline.load(tmpdir / 'extra-field.csv')
+    phase = Phase()
+    phase.load_data(data)
+    phase.do_column_stuff()
+
+    assert len(phase.context.warnings) == 1
+    print(phase.context.warnings)
+    assert 'Extra value found' in phase.context.warnings[1][0]['message']
+
+
+def test_comment_lines(tmpdir):
+    # TODO assuming we write code to make this work - parametrize comments on different lines
+    with open(tmpdir / 'commented_line', 'w') as f:
+        f.write("#crew\n,id,name\n,1,James Kirk\n")
+    assert read_csv(tmpdir / 'commented_line') == [{'id':1, 'name':'James Kirk'}]
+
+
+def test_empty_lines(tmpdir):
+    # TODO assuming we write code to make this work - parametrize empty lines in different places
+    with open(tmpdir / 'commented_line', 'w') as f:
+        f.write("\nid,name\n,1,James Kirk\n")
+    assert read_csv(tmpdir / 'commented_line') == [{'id':1, 'name':'James Kirk'}]
+
+
+def test_strip_spaces(tmpdir):
+    # TODO assuming we write code to make this work - test stripping from values as well as headers
+    with open(tmpdir / 'extra_spaces', 'w') as f:
+        f.write("  id,name\n,1,James Kirk\n")
+    assert read_csv(tmpdir / 'extra_spaces') == [{'id':1, 'name':'James Kirk'}]


### PR DESCRIPTION
I'm rather tempted to stop here, rather than go further down the path of using the builtin csv reader and building 
our own dicts. 

Pros: 
* clevercsv supports stream dict reading, so that would allow a pipeline using that to operate row-by-row and handle large data sets pretty easily some day when we do the other work
* I like the overall approach of being RFC 4180 strict
* The problem with header row containing spaces and not stripping quotes is manageable in phaser code since we're canonicalizing column names anyway
* Empty lines are handled EXCEPT if it's the first line - seems reasonable
* I figured out a way to error if there are duplicate column names - clevercsv has a table reader that just lists all the column names rather than turn them into a dict (and lose the info about dupes)
* Figured out a way to identify rows with too many commas

Cons:
* Comment lines are not handle (and they're not RFC4180 compatible either)
* Rows with not enough values fill in the last values with None -- similar to pandas.read_csv --  not as much warning generation as we would be able to do if we wrote our own
 
At this point I think I can live with the tradeoffs WDYT @jeffkole 