### PR TITLE
Testing batch step more: fixed how it works when the batch step forgets to declare context param

### DIFF
--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -38,7 +38,7 @@ def batch_step(step_function):
             # LMDTODO: Discovered in testing that if the step function doesn't declare the context in its params,
             # when the calling code tries to pass it a batch AND a context, it doesn't even run and its hard to see why.
             # See test test_batch_step_missing_param. The TODO is to fix this for the other step types as well.
-            if 'context' in str(inspect.signature(step_function)):
+            if 'context' in inspect.signature(step_function).parameters.keys():
                 result = step_function(batch, context=context)
             else:
                 result = step_function(batch)

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -1,3 +1,4 @@
+import inspect
 from collections.abc import Mapping, Sequence
 from functools import wraps
 from .pipeline import DataErrorException, DataException, DropRowException, PhaserError
@@ -34,7 +35,13 @@ def batch_step(step_function):
         if __probe__ == PROBE_VALUE:
             return BATCH_STEP
         try:
-            result = step_function(batch, context=context)
+            # LMDTODO: Discovered in testing that if the step function doesn't declare the context in its params,
+            # when the calling code tries to pass it a batch AND a context, it doesn't even run and its hard to see why.
+            # See test test_batch_step_missing_param. The TODO is to fix this for the other step types as well.
+            if 'context' in str(inspect.signature(step_function)):
+                result = step_function(batch, context=context)
+            else:
+                result = step_function(batch)
         except DropRowException as exc:
             raise PhaserError("DropRowException can't be handled in batch steps ") from exc
         if not isinstance(result, Sequence):


### PR DESCRIPTION

When the step doesn't declare context:

```
@batch_step
def my_simple_step(batch):
    ... 
   return batch

```

Then when the step is called in phase when its going through steps:

```
for step_function in steps:
   ...
   step_function(batch, context)
```

It doesn't work - it doesn't even go into the function, I think.  This seems like something that might bite a developer pretty easily - they forget to add the 'context' param, which they don't even want, and can't figure out why their step isn't even running.

 I found out that with the python 'inspect' library one can look at the function's signature and see if it expects a context, and only then pass the context. 
