### PR TITLE
Adds row to exception if exception is thrown in a batch test 

### DIFF
--- a/phaser/exceptions.py
+++ b/phaser/exceptions.py
@@ -3,8 +3,10 @@ class DataException(Exception):
     """ DataException subclasses are thrown when processing data, to trigger the phaser library code to follow
      error-handling policy, often with respect to the row the issue occurs in."""
 
-    def __init__(self, message):
+    def __init__(self, message, **kwargs):
         self.message = message
+        self.row = kwargs.pop('row') if 'row' in kwargs else None
+
 
     def __str__(self):
         return self.message

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -106,12 +106,12 @@ class Context:
 
     def process_exception(self, exc, step, row, error_policy=ON_ERROR_COLLECT):
         """
-        A method to delegate exception handling to.  This is not called within PhaseBase directly,
-        but it is called in the subclasses when they run steps or methods.
+        A method to delegate exception handling to turn into error reporting in standardized way.  Called by
+        phase's step handlers when a phaser data exception or a coding exception occurs
         :param exc: The exception or error thrown
         :param step: What step this occurred in
         :param row: What row of the data this occurred in
-        :param error_policy: One of the error handling policies (ON_ERROR_COLLECT, ON_ERROR_STOP_NOW, etc.)
+        :param error_policy: The phase's chosen error handling policies (ON_ERROR_COLLECT, ON_ERROR_STOP_NOW, etc.)
         :return: Nothing
         """
         if isinstance(exc, PhaserError):

--- a/tests/test_reshape.py
+++ b/tests/test_reshape.py
@@ -37,7 +37,7 @@ def df_transform(df, context):
 
 def test_dataframe_phase(tmpdir):
 
-    phase = ReshapePhase("PhaseWithDFStep", steps=[df_transform])
+    phase = ReshapePhase(name="PhaseWithDFStep", steps=[df_transform])
     phase.load_data(read_csv(fixture_path / 'locations.csv'))
     results = phase.run()
     assert len(results) == 2


### PR DESCRIPTION
Ideally if the batch step throws an exception they can include the row - in which case row number is reported in the existing error reporting