### PR TITLE
Refactors Context, especially to index and store evens differently

### DIFF
--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -51,7 +51,6 @@ class Context:
         self.rwos = {}
         self.working_dir = working_dir
         self.error_policy = error_policy
-        self.current_phase = 'Unknown'
 
     def _get_phase_name(self, phase):
         if phase is None:

--- a/tests/test_basics.py
+++ b/tests/test_basics.py
@@ -111,10 +111,10 @@ def test_column_error_adds_warning():
     phase = Phase("test", columns=[col])
     phase.load_data([{'level': -1}])
     phase.do_column_stuff()
-    warnings_for_row = list(phase.context.warnings.values())[0]
-    assert len(warnings_for_row) == 1
-    assert "level" in warnings_for_row[0]['message']
-    assert warnings_for_row[0]['step'] == 'cast_each_column_value'
+    events_for_row = phase.context.get_events(phase=phase, row_num=1)
+    assert len(events_for_row) == 1
+    assert "level" in events_for_row[0]['message']
+    assert events_for_row[0]['step_name'] == 'cast_each_column_value'
 
 
 @pytest.mark.skip("User can write steps that violate the column contracts, and save the output. we should fix that.")

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -243,7 +243,7 @@ def test_column_can_drop_row():
     phase = Phase(columns=[col])
     phase.load_data([{'Shoe size': '42'}, {'Shoe size': None}])
     phase.do_column_stuff()
-    assert len(phase.context.errors) == 0
+    assert phase.context.phase_has_errors(phase) is False
     assert len(phase.row_data) == 1
     assert phase.row_data[0]['Shoe size'] == 42
 

--- a/tests/test_csv.py
+++ b/tests/test_csv.py
@@ -27,9 +27,8 @@ def test_extra_field_in_csv(tmpdir):
     phase.load_data(data)
     phase.do_column_stuff()
 
-    assert len(phase.context.warnings) == 1
-    print(phase.context.warnings)
-    assert 'Extra value found' in phase.context.warnings[1][0]['message']
+    warning = phase.context.get_events(phase=phase, row_num=1)[0]
+    assert 'Extra value found' in warning['message']
 
 
 @pytest.mark.skip("It would be nice to identify rows with not enough fields...")

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -174,9 +174,9 @@ def test_extra_outputs_to_batch_step():
     extra = ExtraMapping('extra', {})
     phase = Phase(
         steps=[collect_extra_from_batch],
-        extra_outputs=[extra],
-        error_policy=ON_ERROR_STOP_NOW,
+        extra_outputs=[extra]
     )
+    phase.context.error_policy=ON_ERROR_STOP_NOW
     phase.load_data([
         {'number': 12, 'extra': 'A dozen'},
         {'number': 13, 'extra': "Baker's dozen"},
@@ -200,7 +200,8 @@ def test_builtin_step():
 
 
 def test_check_unique_fails(test_data_phase_class):
-    phase = test_data_phase_class(error_policy=ON_ERROR_STOP_NOW)
+    phase = test_data_phase_class()
+    phase.context.error_policy = ON_ERROR_STOP_NOW
     phase.load_data([{'id': '1'}, {'id': '1'}])
     with pytest.raises(DataErrorException):
         phase.run_steps()
@@ -355,9 +356,9 @@ def test_extra_outputs_from_context_step():
     extra = ExtraMapping('extra', {})
     phase = Phase(
         steps=[collect_extra_from_context],
-        extra_outputs=[extra],
-        error_policy=ON_ERROR_STOP_NOW,
+        extra_outputs=[extra]
     )
+    phase.context.error_policy=ON_ERROR_STOP_NOW
     phase.load_data([
         {'number': 12, 'extra': 'A dozen'},
         {'number': 13, 'extra': "Baker's dozen"},
@@ -440,9 +441,9 @@ def test_extra_outputs_from_df_step():
     extra = ExtraMapping('extra', {})
     phase = Phase(
         steps=[collect_extra_from_df],
-        extra_outputs=[extra],
-        error_policy=ON_ERROR_STOP_NOW,
+        extra_outputs=[extra]
     )
+    phase.context.error_policy=ON_ERROR_STOP_NOW
     phase.load_data([
         {'number': 12, 'extra': 'A dozen'},
         {'number': 13, 'extra': "Baker's dozen"},


### PR DESCRIPTION
One goal was to separate errors, warnings and dropped-row events by phase

While doing this, it became necessary to keep track of current phase (although sometimes we can pass the phase into an event creation, sometimes we can't - steps don't know what phase they're in and can't include that in adding errors/warnings.

Because of messing with the signatures of handling exceptions, it became easy just to remove the error_policy from phase and move it to context like we discussed last time.

With this change, Context is also hiding the way it organizes errors/warnings from outside objects. Instead of addressing its dicts directly, we have questions like "phase_has_errors" and "row_has_errors" and the getter for events "get_events".  We probably need a bit more work in this direction, but this PR takes the hit of changing all the tests that were directly querying the context's structures for storing events.

I think this is better on the whole though it does point to some further improvements. I'd like to refactor the exception handling in Context now that it has changed in shape a bit