### PR TITLE
Adds support for sources in CLI

### DIFF
--- a/phaser/cli/command.py
+++ b/phaser/cli/command.py
@@ -2,5 +2,23 @@ class Command:
     def add_arguments(self, parser):
         pass
 
+    def has_incremental_arguments(self, args):
+        """ True if more arguments may be needed after the original set are
+        parsed. False otherwise."""
+        return False
+
+    def add_incremental_arguments(self, args, parser):
+        """ Add any arguments that will only be knowable after the first set of
+        arguments has been parsed. Those arguments would be the ones defined
+        globally as well as any that were added by this command's
+        `add_arguments` method.
+
+        This method will only be called if `has_incremental_arguments` returns True.
+
+        :param args: the arguments parsed so far
+        :param parser: the argument parser for this specific command
+        """
+        pass
+
     def execute(self, args):
         raise NotImplementedError("'execute' must be implemented by a concrete subclass")

--- a/phaser/cli/main.py
+++ b/phaser/cli/main.py
@@ -84,14 +84,18 @@ def main(argv):
         command["parser"] = subparser
         command["instance"].add_arguments(subparser)
 
-    args = parser.parse_args(argv)
+    (args, extras) = parser.parse_known_args(argv)
     if not args.command:
         parser.print_help()
         sys.exit(2)
 
     command = commands.get(args.command)
+    cmd = command["instance"]
+    if cmd.has_incremental_arguments(args):
+        cmd.add_incremental_arguments(args, command["parser"])
+        args = parser.parse_args(argv)
     try:
-        command["instance"].execute(args)
+        cmd.execute(args)
     except phaser.DataException as e:
         print("\nPipeline run failed while processing data.  Errors and row numbers causing errors have been reported.")
     except phaser.PhaserError as e:

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -251,8 +251,7 @@ class Pipeline:
             source for phase in self.phase_instances for source in phase.extra_sources
         ]
 
-    def validate_sources(self):
-        """ Check that all required sources have been initialized."""
+    def sources_needing_initialization(self):
         # Collect the extra sources and outputs from the phases so they can be
         # reconciled and initialized as necessary.  Extra sources that match
         # with extra outputs do not need to be initialized, but extra sources
@@ -264,13 +263,16 @@ class Pipeline:
         extra_output_names = [
             output.name for phase in self.phase_instances for output in phase.extra_outputs
         ]
-        sources_needing_initialization = [
+        return [
             (source if isinstance(source, str) else source.name)
             for source in self.extra_sources
             if (source if isinstance(source, str) else source.name) not in extra_output_names
         ]
+
+    def validate_sources(self):
+        """ Check that all required sources have been initialized."""
         missing_sources = []
-        for source in sources_needing_initialization:
+        for source in self.sources_needing_initialization():
             if not source in self.context.rwos:
                 missing_sources.append(source)
 


### PR DESCRIPTION
There is still an improvement to make to the logic in pipeline that checks which sources need initialization -- namely, the pipeline should check that sources that come from prior phases actually are declared in phases that will be executed before when the source is needed.  But that is an optimization that can be left til later.

The other minor annoyance that I skipped figuring out is how to get the CLI help to display the needed sources.  I think it may require some subclassing of `argparse.ArgumentParser`, which is not something I wanted to get into now.

Addresses #88 