### PR TITLE
Error handling in pipeline, better reporting of which phase

### DIFF
--- a/tests/test_pipeline.py
+++ b/tests/test_pipeline.py
@@ -1,7 +1,6 @@
 from pathlib import Path
 import pytest
-from phaser import Pipeline, Phase, batch_step
-
+from phaser import Pipeline, Phase, batch_step, PhaserError
 
 current_path = Path(__file__).parent
 
@@ -22,3 +21,29 @@ def test_number_go_up(tmpdir):
     assert new_row.row_num > 5
 
 
+def test_pipeline_can_accept_single_phase(tmpdir):
+    # This instantiation call should not cause exceptions even though it passes an object to 'phases' not a list.
+    Pipeline(working_dir=tmpdir, source='dontneed.csv', phases=Phase)
+
+
+def test_error_report_in_phase_init(tmpdir):
+    class PhaseWillErrorOnInit(Phase):
+        def __init__(self):
+            pass  # This will error during pipeline/phase init because the __init__ does not accept a context
+
+    with pytest.raises(PhaserError) as excinfo:
+        pipeline = Pipeline(working_dir=tmpdir, source='dontneed.csv', phases=PhaseWillErrorOnInit)
+    assert "PhaseWillError" in excinfo.value.message
+
+
+def test_error_report_in_pipeline_around_phase(tmpdir):
+    class PhaseWillErrorOnRun(Phase):
+        def run(self):
+            {'id':3}['bogus']  # Cause a KeyError - checked manually that the KeyError is propagated not swallowed
+
+    pipeline = Pipeline(working_dir=tmpdir,
+                        source=(current_path / 'fixture_files' / 'departments.csv'),
+                        phases=[PhaseWillErrorOnRun(steps=[])])
+    with pytest.raises(PhaserError) as excinfo:
+        pipeline.run()
+    assert "PhaseWillErrorOnRun" in excinfo.value.message


### PR DESCRIPTION
Adds the ability for pipeline to handle receiving a single phase in _init__, as well as list of phases
Adds error checking when pipeline initializes phases, to report which one 
Adds error checking when pipeline runs phases, to report which one (issue #55)