### PR TITLE
Enables document generation on Read the Docs

### DIFF
--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -27,6 +27,6 @@ sphinx:
 # Optional but recommended, declare the Python requirements required
 # to build your documentation
 # See https://docs.readthedocs.io/en/stable/guides/reproducible-builds.html
-# python:
-#    install:
-#    - requirements: docs/requirements.txt
+python:
+   install:
+   - requirements: docs/requirements.txt

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,3 +30,6 @@ sphinx:
 python:
    install:
    - requirements: docs/requirements.txt
+   # Install our package before building the docs so autodoc works
+   - method: pip
+     path: .

--- a/.readthedocs.yaml
+++ b/.readthedocs.yaml
@@ -30,6 +30,7 @@ sphinx:
 python:
    install:
    - requirements: docs/requirements.txt
-   # Install our package before building the docs so autodoc works
+   # Install our package and its dependencies before building the docs so autodoc works
+   - requirements: requirements.txt
    - method: pip
      path: .

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -1,0 +1,2 @@
+sphinx
+myst-parser

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,3 @@
 clevercsv
 pandas
 pytest
-sphinx
-myst-parser


### PR DESCRIPTION
Once this PR is merged, we will be able to build documentation in Read the Docs.

The docs will live at phaser.readthedocs.io

We will need to hook up the Github-to-ReadTheDocs webhook in order to build docs for PRs and new branches.  Without the webhook, Read the Docs does not update its information about any other branches than what it knows at the time I set up the project.  This is fine for `main`, but will mean we cannot easily validate documentation as we write it.