### PR TITLE
Moves previous run files to another directory - seems most useful

### DIFF
--- a/phaser/cli/commands/run.py
+++ b/phaser/cli/commands/run.py
@@ -61,7 +61,7 @@ class RunPipelineCommand(Command):
         # pipelines is a tuple of names and values. We want the value which is
         # a class object.
         # LMDTODO DIscuss with Jeff - this doesn't feel like it belongs in a method called "add_incremental_arguments"
-        # it feels more like how the command should initialize or execute
+        # we should separate out "initialize pipeline" as a method of this object, called by main before this is called
         Pipeline = pipelines[0][1]
 
         verbose = args.verbose

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -25,15 +25,12 @@ def test_employee_pipeline(pipeline):
 
 
 def test_reporting(pipeline):
-    f = io.StringIO()
-    with redirect_stdout(f):
-        # Having to grab stdout is probably temporary until we make pipeline more versatile in reporting errors
-        pipeline.run()
-    stdout = f.getvalue()
-    assert "Reporting for phase Validator" in stdout
-    assert "Employee Garak has no ID and inactive" in stdout
-    assert "Reporting for phase Transformer" in stdout
-    assert "'Full name' was added to the row_data and not declared a header'" in stdout
+    pipeline.run()
+    file_data = open(pipeline.errors_and_warnings_file, 'r').read()
+    assert "Beginning errors and warnings for Validator" in file_data
+    assert "Employee Garak has no ID and inactive" in file_data
+    assert "Beginning errors and warnings for Transformer" in file_data
+    assert "'Full name' was added to the row_data and not declared a header'" in file_data
 
 
 def test_line_numbering(pipeline):

--- a/tests/test_multi_source_and_outputs.py
+++ b/tests/test_multi_source_and_outputs.py
@@ -15,11 +15,7 @@ def test_pipeline(tmpdir):
     department_source = current_path / "fixture_files" / "departments.csv"
     pipeline = EmployeeReviewPipeline(source=source, working_dir=tmpdir)
     pipeline.init_source('departments', department_source)
-    f = io.StringIO()
-    with redirect_stdout(f):
-        # Having to grab stdout is probably temporary until we make pipeline more versatile in reporting errors
-        pipeline.run()
-    stdout = f.getvalue()
+    pipeline.run()
 
     assert os.path.exists(tmpdir / 'Validation_output_more-employees.csv')
     assert os.path.exists(tmpdir / 'Transformation_output_more-employees.csv')
@@ -54,7 +50,8 @@ def test_pipeline(tmpdir):
         { 'key': '2', 'value': '2' },
     ]
 
-    assert "Reporting for phase Validation" in stdout
-    assert "Employee Garak has no ID and inactive" in stdout
-    assert "Reporting for phase Transformation" in stdout
-    assert "'Full name' was added to the row_data and not declared a header'" in stdout
+    file_data = open(pipeline.errors_and_warnings_file, 'r').read()
+    assert "Beginning errors and warnings for Validation" in file_data
+    assert "Employee Garak has no ID and inactive" in file_data
+    assert "Beginning errors and warnings for Transformation" in file_data
+    assert "'Full name' was added to the row_data and not declared a header'" in file_data


### PR DESCRIPTION
As I started working with this, even testing grew a little more difficult because the files you want to look at are in a different sub dir each run (if the checkpoints and errors and warnings are put in a randomly generated or timestamped directory)

so instead I thought to MOVE the previous run files, if present, to a timestamped subdirectory.  