### PR TITLE
Phase save errors bubble up - including error if no rows return

### DIFF
--- a/phaser/cli/commands/run.py
+++ b/phaser/cli/commands/run.py
@@ -82,4 +82,7 @@ class RunPipelineCommand(Command):
             self.pipeline.init_source(source, args[source])
 
         print(f"Running pipeline '{self.pipeline.__class__.__name__}'")
-        self.pipeline.run()
+        try:
+            self.pipeline.run()
+        except phaser.DataException as e:
+            print("Error processing data.  ", e.message)

--- a/phaser/column.py
+++ b/phaser/column.py
@@ -130,7 +130,6 @@ class Column:
         if not self.blank and not value:  # Python boolean casting returns false if string is empty
             raise self.use_exception(f"Column `{self.name}' had blank value")
         if self.allowed_values and not (value in self.allowed_values):
-            print(f"LMD: self use exception {self.use_exception}")
             raise self.use_exception(f"Column '{self.name}' had value {value} not found in allowed values")
 
     def fix_value(self, value):

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -102,6 +102,8 @@ class Context:
         return False
 
     def phase_has_errors(self, phase_name):
+        if phase_name not in self.events.keys():
+            raise PhaserError(f"Pass in a phase name to look up errors, {phase_name} not found in context events")
         for event_list in self.events[phase_name].values():
             if any(event['type'] == Context.ERROR for event in event_list):
                 return True

--- a/tests/test_phase.py
+++ b/tests/test_phase.py
@@ -3,7 +3,8 @@ import pandas as pd
 from pathlib import Path
 import pytest  # noqa # pylint: disable=unused-import
 
-from phaser import Phase, row_step, Pipeline, Column, IntColumn, read_csv, DataException, dataframe_step
+from phaser import Phase, row_step, Pipeline, Column, IntColumn, read_csv, DataException, dataframe_step, ON_ERROR_WARN, \
+    ON_ERROR_DROP_ROW
 from steps import adds_row
 
 current_path = Path(__file__).parent
@@ -82,7 +83,7 @@ def test_have_and_run_steps(tmpdir):
 
 
 def test_column_error_drops_row():
-    col = IntColumn(name='level', min_value=0, on_error='drop_row')
+    col = IntColumn(name='level', min_value=0, on_error=ON_ERROR_DROP_ROW)
     phase = Phase("test", columns=[col])
     phase.load_data([{'level': -1}])
     phase.do_column_stuff()
@@ -90,7 +91,7 @@ def test_column_error_drops_row():
 
 
 def test_column_error_adds_warning():
-    col = IntColumn(name='level', min_value=0, on_error='warn')
+    col = IntColumn(name='level', min_value=0, on_error=ON_ERROR_WARN)
     phase = Phase("test", columns=[col])
     phase.load_data([{'level': -1}])
     phase.do_column_stuff()


### PR DESCRIPTION
 When a phase has no rows to return (they're all dropped), this was causing no CSV to save, and a confusing error trying to load the CSV for the next phase.  This makes the error more explicit, and also makes sure that errors AROUND the running of the phase are not swallowed up by the error handling for actually running the phase.