### PR TITLE
Suppresses row count warning if the step declares that it doesn't want that check

### DIFF
--- a/phaser/builtin_steps.py
+++ b/phaser/builtin_steps.py
@@ -60,7 +60,7 @@ def filter_rows(func):
     those create a DROPPED_ROW message for each one.  This will summarize how many rows were dropped.
     """
 
-    @batch_step
+    @batch_step(check_size=False)
     def filter_rows_step(batch, context, **kwargs):
         new_batch = [row for row in batch if func(row)]
         num_dropped = len(batch) - len(new_batch)

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -116,8 +116,10 @@ class Context:
     def get_events(self, phase=None, row_num=None):
         if row_num and phase:
             return self.events[phase.name][row_num]
+        elif phase:
+            return self.events[phase.name]
         else:
-            raise PhaserError("Case not handled yet, not sure how this code is going to shake out")
+            return self.events
 
     def add_variable(self, name, value):
         """ Add variables that are global to the pipeline and accessible to steps and internal methods """

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -113,7 +113,7 @@ def row_step(func=None, *, extra_sources=None, extra_outputs=None):
     wrapper = StepWrapper(ROW_STEP, postprocess=postprocess)
     return wrapper.wrap(func, extra_sources=extra_sources, extra_outputs=extra_outputs)
 
-def batch_step(func=None, *, extra_sources=None, extra_outputs=None):
+def batch_step(func=None, *, extra_sources=None, extra_outputs=None, check_size=False):
     """ This decorator allows the Phase run logic to determine that this step needs to run on the
     whole batch by adding a 'probe' response
     """
@@ -127,12 +127,12 @@ def batch_step(func=None, *, extra_sources=None, extra_outputs=None):
         if not isinstance(result, Sequence):
             raise PhaserError(
                 f"Step {step_function} returned a {result.__class__} rather than a list of rows")
-        return result
+        return result, check_size
 
     wrapper = StepWrapper(BATCH_STEP, postprocess=postprocess, handle_exception=handle_exception)
     return wrapper.wrap(func, extra_sources=extra_sources, extra_outputs=extra_outputs)
 
-def dataframe_step(func=None, *, pass_row_nums=True, extra_sources=None, extra_outputs=None):
+def dataframe_step(func=None, *, pass_row_nums=True, extra_sources=None, extra_outputs=None, check_size=False):
     def handle_exception(step_function, exc):
         if isinstance(exc, DropRowException):
             raise PhaserError("DropRowException can't be handled in steps operating on bulk data ") from exc
@@ -148,7 +148,7 @@ def dataframe_step(func=None, *, pass_row_nums=True, extra_sources=None, extra_o
         if not isinstance(result, pd.DataFrame):
             raise PhaserError(
                 f"Step {step_function} returned a {result.__class__} rather than a pandas DataFrame")
-        return result.to_dict(orient='records')
+        return result.to_dict(orient='records'), check_size
 
     wrapper = StepWrapper(
         DATAFRAME_STEP,

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -53,6 +53,12 @@ class StepWrapper():
                 if __probe__ == PROBE_VALUE:
                     return self.probe  # Allows Phase to probe a step for how to call it
 
+                # Note that context will always be passed in during regular operation of phases and pipelines. HOWEVER,
+                # we want the DX for tests of wrapped steps to just be simple - call the step with a batch or a row
+                # and check the return value.  So instead, we check for context being correct when we need it.
+                if context is not None and not "Context" in str(context.__class__):
+                    raise PhaserError("A step requiring extra data sources cannot be run without a context")
+
                 try:
                     outputs = outputs or {}
                     kwargs = {}
@@ -62,6 +68,7 @@ class StepWrapper():
                     if self.probe != CONTEXT_STEP:
                         if 'context' in parameters:
                             kwargs['context'] = context
+
 
                     for source in extra_sources:
                         kwargs[source] = context.get_source(source)

--- a/tests/test_builtin_steps.py
+++ b/tests/test_builtin_steps.py
@@ -99,7 +99,6 @@ def test_filter_rows():
     assert len(phase.context.events['foo']) == 1  # No rows should have warnings besides the 'none' row
 
 
-@pytest.mark.skip("TODO: we have not yet written the code to suppress the warning")
 def test_filter_rows_doesnt_warn_extra():
     phase = Phase(name='foo', steps=[filter_rows(lambda row: row['rank'] == "Doctor")])
     phase.load_data(read_csv(current_path / 'fixture_files' / 'crew.csv'))

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -42,18 +42,22 @@ def test_context_available_to_step():
     transformer.run_steps()
     assert transformer.row_data[0]['secret'] == "I'm always angry"
 
-def test_extra_sources_to_row_step():
-    @row_step(extra_sources=['extra'])
-    def append_extra_to_row(row, extra):
-        row['extra'] = extra[row['number']]
-        return row
 
-    extra = ExtraMapping('extra', {12: 'A dozen', 13: "Baker's dozen"})
+@row_step(extra_sources=['extra'])
+def append_extra_to_row(row, extra):
+    row['extra'] = extra[row['number']]
+    return row
+
+
+EXTRA_DATA = ExtraMapping('extra', {12: 'A dozen', 13: "Baker's dozen"})
+
+
+def test_extra_sources_to_row_step():
     phase = Phase(
         steps=[append_extra_to_row],
-        extra_sources=[extra],
+        extra_sources=[EXTRA_DATA],
     )
-    phase.context.set_source('extra', extra)
+    phase.context.set_source('extra', EXTRA_DATA)
     phase.load_data([{'number': 12}, {'number': 13}])
     phase.run_steps()
     assert phase.row_data == [
@@ -61,12 +65,22 @@ def test_extra_sources_to_row_step():
         {'number': 13, 'extra': "Baker's dozen"},
     ]
 
-def test_extra_outputs_to_row_step():
-    @row_step(extra_outputs=['extra'])
-    def collect_extra_from_row(row, extra):
-        extra[row['number']] = row['extra']
-        return row
 
+def test_extra_sources_but_no_context():
+    # When the user tries to test a step like _append_extra_to_row_ and forgets to add a context, we should
+    # provide a helpful error.
+    with pytest.raises(PhaserError) as exc_info:
+        append_extra_to_row({'original': 'data'}, EXTRA_DATA)
+    assert "without a context" in exc_info.value.message
+
+
+@row_step(extra_outputs=['extra'])
+def collect_extra_from_row(row, extra):
+    extra[row['number']] = row['extra']
+    return row
+
+
+def test_extra_outputs_to_row_step():
     extra = ExtraMapping('extra', {})
     phase = Phase(
         steps=[collect_extra_from_row],
@@ -83,6 +97,15 @@ def test_extra_outputs_to_row_step():
         12: 'A dozen',
         13: "Baker's dozen",
     }
+
+
+def test_extra_outputs_but_no_context():
+    # When the user tries to test a step like _collect_extra_from_row_ and forgets to pass a context to add
+    # extra outputs to, we need to test for that and return a helpful error.
+    with pytest.raises(PhaserError) as exc_info:
+        collect_extra_from_row({'id': 1, 'what': 'the row'}, ExtraMapping('extra', {}))
+    assert "without a context" in exc_info.value.message
+
 
 # Batch steps
 


### PR DESCRIPTION
I'm not entirely happy about passing a tuple back to the execute_batch_step function, but otherwise the phase doesn't know what the decorator parameters are, and the decorator doesn't know what the phase context is to add warnings to.