### PR TITLE
Fixes two broken tests, issue #142, and enables tests now they're fixed

### DIFF
--- a/docs/user/usage.md
+++ b/docs/user/usage.md
@@ -39,6 +39,38 @@ so it's worth reading up on the parameters of different Column types.
 * [DateColumn](#DateColumn)
 
 
+## Declarative column fixing
+
+Column declarations can have common operations passed in as a list of functions to apply to the column values
+to "fix" them.  For example, it's pretty common to have users type in values like "new", "NEW" and "New",
+so asking the value to always be converted to upper-case via the 'upper' method makes those consistent.
+
+```
+Column('status', fix_value_fn='upper')
+```
+
+These can also be in a list of functions that are applied in order:
+
+```
+Column('status', fix_value_fn=['strip', 'upper'])
+```
+
+Note that the column type is applied first, so the functions must work on the given data type.  The following works:
+
+```
+IntColumn('value', fix_value_fn='abs')
+```
+
+But the next example will give an error because python 'strip' doesn't work on dates:
+
+```
+ERR: DateColumn(name='date', fix_value_fn='strip')
+```
+
+Happily, the above example will convert ' 2023-01-01 '  to a date without explicitly asking it to strip spaces.
+Should you require a "fix_value_fn" that applies before the column is cast to its data type, a custom Column class
+may be required instead (see [custom validation for columns](#custom-column-validation))
+
 ## Row steps
 
 ## Batch steps

--- a/phaser/column.py
+++ b/phaser/column.py
@@ -80,6 +80,8 @@ class Column:
         if isinstance(self.rename, str):
             self.rename = [self.rename]
         self.allowed_values = allowed_values
+        if self.allowed_values is not None and not isinstance(self.allowed_values, Iterable):
+            self.allowed_values = [self.allowed_values]
         self.save = save
         self.use_exception = DataErrorException
         if on_error and on_error not in Column.ON_ERROR_VALUES.keys():
@@ -106,10 +108,11 @@ class Column:
 
         new_value = self.cast(value)   # Cast to another datatype (int, float) if subclass
 
-        self.check_value(new_value)
         fixed_value = self.fix_value(new_value)
         if fixed_value is None and new_value is not None:
             logger.debug(f"Column {self.name} set value to None while fixing value")
+
+        self.check_value(fixed_value)
         row[self.name] = fixed_value
         return row
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -98,7 +98,6 @@ def test_multiple_functions():
     assert col.fix_value("  ACTIVE  ") == "Active  "
 
 
-@pytest.mark.skip("Column value fixing should apply BEFORE checking allowed_values, issue #142")
 def test_order_of_allowed_value_checking():
     col = Column('sale_type',
                  fix_value_fn='capitalize',
@@ -124,7 +123,6 @@ def test_allowed_values_cast_to_array():
     col1.check_and_cast_value({'only-one': 'highlander'})
 
 
-@pytest.mark.skip("Doesn't work yet - we don't wrap the value of allowed_values in an array if it isn't one")
 def test_allowed_values_cast_int_to_array():
     col2 = IntColumn(name='answer', allowed_values=42)
     col2.check_and_cast_value({'answer': '42'})


### PR DESCRIPTION
The tests are pretty descriptive:
 - if we're fixing column  values (by applying consistent capitalization, stripping spaces, etc) that should happen before we see if the value is in an enumerated list of possible valeus
 - The enumerated list of possible values should be a list!  otherwise we can wrap it in one and assume the programmer meant for it to be a single value.

Fixes #142 