### PR TITLE
Fixes two small bugs that both involved checking allowed_values

### DIFF
--- a/phaser/column.py
+++ b/phaser/column.py
@@ -80,6 +80,10 @@ class Column:
         if isinstance(self.rename, str):
             self.rename = [self.rename]
         self.allowed_values = allowed_values
+        if self.allowed_values:
+            if not isinstance(self.allowed_values, Iterable) or isinstance(self.allowed_values, str):
+                # Strings are iterables in python, yet we don't want to break up a string into letters
+                self.allowed_values = [self.allowed_values]
         self.save = save
         self.use_exception = DataErrorException
         if on_error and on_error not in Column.ON_ERROR_VALUES.keys():
@@ -103,13 +107,12 @@ class Column:
         value = row.get(self.name)
         if self.null is False and value is None:
             raise self.use_exception(f"Null value found in column {self.name}")
-
         new_value = self.cast(value)   # Cast to another datatype (int, float) if subclass
 
-        self.check_value(new_value)
         fixed_value = self.fix_value(new_value)
         if fixed_value is None and new_value is not None:
             logger.debug(f"Column {self.name} set value to None while fixing value")
+        self.check_value(fixed_value)
         row[self.name] = fixed_value
         return row
 

--- a/tests/test_columns.py
+++ b/tests/test_columns.py
@@ -98,7 +98,6 @@ def test_multiple_functions():
     assert col.fix_value("  ACTIVE  ") == "Active  "
 
 
-@pytest.mark.skip("Column value fixing should apply BEFORE checking allowed_values, issue #142")
 def test_order_of_allowed_value_checking():
     col = Column('sale_type',
                  fix_value_fn='capitalize',
@@ -124,7 +123,6 @@ def test_allowed_values_cast_to_array():
     col1.check_and_cast_value({'only-one': 'highlander'})
 
 
-@pytest.mark.skip("Doesn't work yet - we don't wrap the value of allowed_values in an array if it isn't one")
 def test_allowed_values_cast_int_to_array():
     col2 = IntColumn(name='answer', allowed_values=42)
     col2.check_and_cast_value({'answer': '42'})


### PR DESCRIPTION
Fixes order of column operation - fix, then check (allowed_values or other checks) .  Also casts allowed_values to array if it isn't one.

Fixes #142 