### PR TITLE
Slight reorg of phaser run command to fix a comment I'd left behind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,7 @@ cython_debug/
 # according to GH's template .gitignore but we could always get more nuanced later. -Lisa
 .idea/
 docs/_build/*
+
+# This directory name is used in examples as an output directory, so if a developer creates it while following
+# CLI examples, it will now be ignored.
+phaser_output

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -10,7 +10,7 @@ throughout the pipeline.
 
 ```
 % cd tests
-% python -m phaser run employees ./phaser_output fixture_files/employees.csv
+% python -m phaser run employees ../phaser_output fixture_files/employees.csv
 Running pipeline 'EmployeeReviewPipeline'
 
 % cat ~/phaser_output/errors_and_warnings.txt

--- a/docs/user/cli.md
+++ b/docs/user/cli.md
@@ -10,7 +10,7 @@ throughout the pipeline.
 
 ```
 % cd tests
-% python -m phaser run employees ~/phaser_output fixture_files/employees.csv
+% python -m phaser run employees ./phaser_output fixture_files/employees.csv
 Running pipeline 'EmployeeReviewPipeline'
 
 % cat ~/phaser_output/errors_and_warnings.txt


### PR DESCRIPTION
In the comment I'd left, I thought we could move the pipeline instantiation out entirely.   But it is needed to know which args to expect (the arguments with the additional sources needed for the pipeline to run), so instead broke the instantiation out into another method for better readability.

Also remembered to add the 'phaser_output' directory as an ignored directory, since I tend to use it and others might also - it's a convenient place to put output when developing, and it's the output location used in examples.