### PR TITLE
Makes the diff utility skip phases that renumber all the rows

### DIFF
--- a/phaser/cli/commands/diff.py
+++ b/phaser/cli/commands/diff.py
@@ -22,12 +22,16 @@ from pathlib import Path
 
 import phaser
 from phaser.cli import Command
+from phaser.column import make_strict_name
 from phaser.table_diff import IndexedTableDiffer
 
 class DiffCommand(Command):
     def __init__(self):
         super().__init__()
         self.pipeline = None
+        self.working_dir = None
+        self.all_column_renames = {}
+        self.all_phases_diffable=True
 
     def add_arguments(self, parser):
         parser.add_argument("pipeline_name",
@@ -54,66 +58,80 @@ class DiffCommand(Command):
         # a class object.
         Pipeline = pipelines[0][1]
 
-        working_dir = Path(args['working_dir'])
-        source_file = working_dir / Pipeline.source_copy_filename()
+        self.working_dir = Path(args['working_dir'])
+        source_file = self.working_dir / Pipeline.source_copy_filename()
         source = Pipeline.load(source_file)
 
-        pipeline_instance = Pipeline(working_dir, source_file)
+        pipeline_instance = Pipeline(self.working_dir, source_file)
         pipeline_instance.setup_phases()
         phases = pipeline_instance.phase_instances
         if len(phases) > 1:
             compare_prev = source
             prev_name = "source"
-            all_column_renames = {}
             for phase in phases:
                 output_name = pipeline_instance.phase_save_filename(phase)
-                output = Pipeline.load(working_dir / output_name)
-                phase_column_renames = get_real_renamed_columns(phase, compare_prev[0].keys(), output[0].keys())
-                build_full_pipeline_rename_map(phase_column_renames, all_column_renames)
-                diff_filename = working_dir / f"diff_to_{output_name}.html"
-                print(f"Diff of {prev_name} and {output_name} will be saved in {diff_filename}")
-                differ = IndexedTableDiffer(compare_prev, output, column_renames=phase_column_renames)
-                with open(diff_filename, 'w') as diff_file:
-                    diff_file.write(differ.html())
-                print_summary(differ)
+                output = pipeline_instance.load(self.working_dir / output_name)
+                self.diff_phase(phase, output, output_name, compare_prev, prev_name)
+                compare_prev = pipeline_instance.load(self.working_dir / output_name) # Reload to start read from beginning
                 prev_name = output_name
-                compare_prev = Pipeline.load(working_dir / output_name) # Reload to start read from beginning
             last_one = compare_prev
         else:
-            last_one = Pipeline.load(working_dir / pipeline_instance.phase_save_filename(phases[0]))
-            all_column_renames = get_real_renamed_columns(phases[0], source[0].keys(), last_one[0].keys())
+            last_one = Pipeline.load(self.working_dir / pipeline_instance.phase_save_filename(phases[0]))
+            self.all_column_renames = get_real_renamed_columns(phases[0], source[0].keys(), last_one[0].keys())
 
         # Full pipeline diff
-        source = Pipeline.load(source_file)  # Reload to read file from beginning
-        diff_filename = working_dir / f"diff_pipeline.html"
-        differ = IndexedTableDiffer(source, last_one, column_renames=all_column_renames)
-        print(f"Entire pipeline changes in {diff_filename}")
-        with open(diff_filename, 'w') as diff_file:
-            diff_file.write(differ.html())
-        print_summary(differ)
-        # TODO: create a wrapper HTML file that allows the user to navigate between the different diffs when the
-        # wrapper is loaded automatically into the browser after the command runs?
+        if self.all_phases_diffable:
+            source = Pipeline.load(source_file)  # Reload to read file from beginning
+            diff_filename = self.working_dir / f"diff_pipeline.html"
+            differ = IndexedTableDiffer(source, last_one, column_renames=self.all_column_renames)
+            print(f"Entire pipeline changes in {diff_filename}")
+            with open(diff_filename, 'w') as diff_file:
+                diff_file.write(differ.html())
+            print_summary(differ)
 
 
-def build_full_pipeline_rename_map(phase_column_renames, all_column_renames):
-    for old_name, new_name in phase_column_renames.items():
-        if old_name in all_column_renames.values():
-            reverse_rename_lookup = {v: k for k, v in all_column_renames.items()}
-            old_old_name = reverse_rename_lookup[old_name]
-            all_column_renames[old_old_name] = new_name
+    def diff_phase(self, phase, output, output_name, input, input_name):
+        if phase.diffable():
+            phase_column_renames = get_real_renamed_columns(phase, input[0].keys(), output[0].keys())
+            self.build_full_pipeline_rename_map(phase_column_renames, self.all_column_renames)
+            diff_filename = self.working_dir / f"diff_to_{output_name}.html"
+            print(f"Diff of {input_name} and {output_name} will be saved in {diff_filename}")
+            differ = IndexedTableDiffer(input, output, column_renames=phase_column_renames)
+            with open(diff_filename, 'w') as diff_file:
+                diff_file.write(differ.html())
+            print_summary(differ)
         else:
-            all_column_renames[old_name] = new_name
+            print(f"Skipping diff of {input_name} and {output_name} - phase may reorganize data")
+            self.all_phases_diffable = False
+
+    def build_full_pipeline_rename_map(self, phase_column_renames, all_column_renames):
+        for old_name, new_name in phase_column_renames.items():
+            if old_name in all_column_renames.values():
+                reverse_rename_lookup = {v: k for k, v in all_column_renames.items()}
+                old_old_name = reverse_rename_lookup[old_name]
+                all_column_renames[old_old_name] = new_name
+            else:
+                all_column_renames[old_name] = new_name
 
 
 def get_real_renamed_columns(phase, old_column_names, new_column_names):
     # We want to know which columns were likely to have been renamed.  From the phase we get all possible
     # mappings - but some mappings weren't used (didn't appear in the source file) or were used then deleted
     # (don't appear in the destination file)
-    all_possible_column_renames = phase.column_rename_dict()
+    all_explicit_column_renames = phase.column_rename_dict()
     actual_column_renames = {}
-    for old, new in all_possible_column_renames.items():
+    for old, new in all_explicit_column_renames.items():
+        # If the old name didn't appear in the input, the rename didn't ACTUALLY happen
         if old in old_column_names and new in new_column_names:
             actual_column_renames[old] = new
+    # Along with the renames, there are also columns that change in capitalization/underscore to the programmer's
+    # preferred variant
+    strict_new_names = {make_strict_name(name): name for name in new_column_names}
+    for old in old_column_names:
+        strict_old_name = make_strict_name(old)
+        if strict_old_name in strict_new_names.keys() and strict_new_names[strict_old_name] != old:
+            actual_column_renames[old] = strict_new_names[strict_old_name]
+
     return actual_column_renames
 
 

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -138,6 +138,9 @@ class PhaseBase(ABC):
         except Exception as exc:
             self.context.process_exception(exc, self, step, row=None)
 
+    def diffable(self):
+        return False
+
 
 class Phase(PhaseBase):
     """ The organizing principle for data transformation steps and column definitions is the phase.  A phase can
@@ -309,3 +312,6 @@ class Phase(PhaseBase):
                     self.context.add_warning('consistency_check', row,
                         f"New field '{field_name}' was added to the row_data and not declared a header")
                     added_header_names.add(field_name)
+
+    def diffable(self):
+        return not self.renumber


### PR DESCRIPTION
* Also fixes how some column names like canonicalizing LATITUDE to the capitalization preferred by the developer, were not noted as renames in the diff
*  Also fixes how row numbers were sorting as strings in the diff output, sorting row '9' after row '10'
* Also changes formatting of deleted rows to use a CSS class

Fixes #171