### PR TITLE
Datetime parsing without dateutil library, and with more rigour

### DIFF
--- a/phaser/column.py
+++ b/phaser/column.py
@@ -297,8 +297,8 @@ class FloatColumn(IntColumn):
 class DateTimeColumn(Column):
     """
     Sets up column to do python datetime type, format, null and default checking on values, as well as
-    other column functionality.  Supports ISO8601/RFC3339 date-time formatting -- less rigorous and knowable
-    formats may need to be specified with datetime_format as used by datetime.strptime.
+    other column functionality.  Supports ISO8601/RFC3339 date-time formatting.  Supply a strptime-style
+    format string to datetime_format to parse other formats.
 
     :param name: The preferred name/presentation of the column, e.g. "Date of Birth" or "first_name"
     :param required: If the column is required, the phase will present errors if it is missing.
@@ -382,7 +382,7 @@ class DateTimeColumn(Column):
 class DateColumn(DateTimeColumn):
     """
     Sets up column to do python date type, format, null and default checking on values, as well as
-    other column functionality.
+    other column functionality.  Supports only a few unambiguous formats - otherwise specify date_format parameter.
 
     :param name: The preferred name/presentation of the column, e.g. "Date of Birth" or "first_name"
     :param required: If the column is required, the phase will present errors if it is missing.

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -1,6 +1,5 @@
 from abc import ABC, abstractmethod
 from copy import deepcopy
-import pandas as pd
 
 from .column import make_strict_name, Column
 from .pipeline import DropRowException, DataException, PhaserError
@@ -33,7 +32,7 @@ class PhaseBase(ABC):
         Note that in normal operation, a Records object is passed in with Record objects and row numbers -
         however if a Phase is being used in tests, it makes testing a lot easier if load_data can take a
         raw list of dicts and row numbers get added.  """
-        if isinstance(data, pd.DataFrame):
+        if "DataFrame" in str(data.__class__):
             self.headers = data.columns.values.tolist()
             data = data.to_dict('records')
 


### PR DESCRIPTION
While working on the JSON support, I discovered that we still had a couple library imports hanging around that were
only working due to my system not being clean... and while investigating if those could be removed, realized that more rigorous date parsing than dateutil supplies would be a good idea anyhow.

The problem was that if a column had both 1/31/2024 and 31/1/2024, dateutil would happily parse them both as Jan 31 2024, rather than flag one as an error.  This means that a data file saved from Excel in one locale (m/d/y) would be processed in phaser in another locale (d/m/year) with inconsistent results, rather than flagging an error.

If we were to build in automatic detection of m/d/y vs d/m/y it should at least take into account the whole column.  
