### PR TITLE
Allows columns to be dropped at the end of a phase even if created mid-phase by flatten

### DIFF
--- a/phaser/builtin_steps.py
+++ b/phaser/builtin_steps.py
@@ -100,7 +100,7 @@ def _merge_values_if_no_collisions(row, key_name):
     for inner_key, inner_value in value.items():
         new_column_name = f"{key_name}__{inner_key}"
         if new_column_name in row.keys():
-            raise DataErrorException(f"Error flattening nested data; key {key_name} already in row")
+            raise DataErrorException(f"Error flattening nested data; key {new_column_name} already in row")
         new_row[new_column_name] = inner_value
         new_columns.append(new_column_name)
     del new_row[key_name]

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -248,7 +248,8 @@ class Phase(PhaseBase):
             can assume the correct type). """
             new_row = row
             for col in self.columns:
-                new_row = col.check_and_cast_value(new_row, context)
+                if col.required or col.save or col.name in new_row.keys():
+                    new_row = col.check_and_cast_value(new_row, context)
             return new_row
 
         # Header work is done first
@@ -315,13 +316,15 @@ class Phase(PhaseBase):
         added_header_names = set()
         for row in self.row_data:
             for field_name in row.keys():
-                if field_name not in self.headers and field_name not in added_header_names:
+                if (field_name not in self.headers
+                        and field_name not in added_header_names
+                        and field_name not in [c.name for c in self.columns]):
                     # TODO: Fix -- context adds warnings to the 'current_row'
                     # record, not the record associated with the row passed in
                     # here. In this method, all of the errors are logged on the
                     # last row of the data, because current_row is not changed.
                     self.context.add_warning('consistency_check', row,
-                        f"New field '{field_name}' was added to the row_data and not declared a header")
+                        f"New field '{field_name}' was added to the row_data and not declared as a column")
                     added_header_names.add(field_name)
 
     def diffable(self):

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -196,7 +196,7 @@ class Pipeline:
         logger.info(f"{phase.name} saved output to {destination}")
         self.report_errors_and_warnings(phase.name)
         if self.context.phase_has_errors(phase.name):
-            raise DataException(f"Phase '{phase.name}' failed with errors.")
+            raise DataException(f"Phase '{phase.name}' failed with errors.  Errors saved to '{self.errors_and_warnings_file()}'")
 
     def report_errors_and_warnings(self, phase_name):
         """ TODO: different formats, flexibility:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -30,7 +30,7 @@ def test_reporting(pipeline):
     assert "Beginning errors and warnings for Validator" in file_data
     assert "Employee Garak has no ID and inactive" in file_data
     assert "Beginning errors and warnings for Transformer" in file_data
-    assert "'Full name' was added to the row_data and not declared a header'" in file_data
+    assert "'Full name' was added to the row_data and not declared as a column'" in file_data
 
 
 def test_line_numbering(pipeline):

--- a/tests/test_multi_source_and_outputs.py
+++ b/tests/test_multi_source_and_outputs.py
@@ -54,7 +54,7 @@ def test_pipeline(tmpdir):
     assert "Beginning errors and warnings for Validation" in file_data
     assert "Employee Garak has no ID and inactive" in file_data
     assert "Beginning errors and warnings for Transformation" in file_data
-    assert "'Full name' was added to the row_data and not declared a header'" in file_data
+    assert "'Full name' was added to the row_data and not declared as a column'" in file_data
 
     # The extra output should be listed in the expected outputs.
     assert 'managers.csv' in pipeline.expected_outputs()


### PR DESCRIPTION
In working with JSON data, I discovered that I wanted to flatten the data and drop columns in the same phase - because while flattening structured data, some of it I might want to keep to work with, and some I might want to drop to reduce size/mess.

This didn't quite work immediately, because when creating the Column to declare that the column should not be saved at the end, the column was _created_ at the beginning of the Phase - then flatten had an error trying to add a nested column that shouldn't have been created in the first place.  

I think the right thing to do about that is that when Phase is doing its column work at the beginning, specifically when running 'cast_each_column_value': if a column is not required and won't be saved and doesn't have a value, we shouldn't be creating it.  Now dropping a new column that is created by 'flatten_column' works. 

While doing this, I saw some warnings about creating columns that hadn't been declared and wondered if it actually works to declare a column and avoid the warning.  With a fix to the 'check_headers_consistent' method in Phase, this now can work --previously that method didn't see if headers were declared in the Column list. 