### PR TITLE
Test steps are testable

### DIFF
--- a/phaser/builtin_steps.py
+++ b/phaser/builtin_steps.py
@@ -100,7 +100,7 @@ def _merge_values_if_no_collisions(row, key_name):
     for inner_key, inner_value in value.items():
         new_column_name = f"{key_name}__{inner_key}"
         if new_column_name in row.keys():
-            raise DataErrorException(f"Error flattening nested data; key {key_name} already in row")
+            raise DataErrorException(f"Error flattening nested data; key {new_column_name} already in row")
         new_row[new_column_name] = inner_value
         new_columns.append(new_column_name)
     del new_row[key_name]

--- a/phaser/phase.py
+++ b/phaser/phase.py
@@ -248,7 +248,8 @@ class Phase(PhaseBase):
             can assume the correct type). """
             new_row = row
             for col in self.columns:
-                new_row = col.check_and_cast_value(new_row, context)
+                if col.required or col.save or col.name in new_row.keys():
+                    new_row = col.check_and_cast_value(new_row, context)
             return new_row
 
         # Header work is done first
@@ -315,13 +316,15 @@ class Phase(PhaseBase):
         added_header_names = set()
         for row in self.row_data:
             for field_name in row.keys():
-                if field_name not in self.headers and field_name not in added_header_names:
+                if (field_name not in self.headers
+                        and field_name not in added_header_names
+                        and field_name not in [c.name for c in self.columns]):
                     # TODO: Fix -- context adds warnings to the 'current_row'
                     # record, not the record associated with the row passed in
                     # here. In this method, all of the errors are logged on the
                     # last row of the data, because current_row is not changed.
                     self.context.add_warning('consistency_check', row,
-                        f"New field '{field_name}' was added to the row_data and not declared a header")
+                        f"New field '{field_name}' was added to the row_data and not declared as a column")
                     added_header_names.add(field_name)
 
     def diffable(self):

--- a/phaser/pipeline.py
+++ b/phaser/pipeline.py
@@ -196,7 +196,7 @@ class Pipeline:
         logger.info(f"{phase.name} saved output to {destination}")
         self.report_errors_and_warnings(phase.name)
         if self.context.phase_has_errors(phase.name):
-            raise DataException(f"Phase '{phase.name}' failed with errors.")
+            raise DataException(f"Phase '{phase.name}' failed with errors.  Errors saved to '{self.errors_and_warnings_file()}'")
 
     def report_errors_and_warnings(self, phase_name):
         """ TODO: different formats, flexibility:

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -3,6 +3,7 @@ from collections.abc import Mapping, Sequence
 from functools import wraps, partial
 from .exceptions import DataErrorException, DropRowException, PhaserError
 from .pipeline import PHASER_ROW_NUM
+from .records import Records
 
 ROW_STEP = "ROW_STEP"
 BATCH_STEP = "BATCH_STEP"
@@ -179,7 +180,10 @@ def dataframe_step(func=None, *, pass_row_nums=True, extra_sources=None, extra_o
         try:
             from pandas import DataFrame
             dataframe = DataFrame.from_records(target)
-            if pass_row_nums:
+            if pass_row_nums and isinstance(target, Records):
+                # We used to assume row numbers, but that doesn't work well in renumbering phases.
+                # We used to assume that the data was in Records format, but that prevents developers
+                # from directly testing their step functions by passing dict data in their unit tests.
                 dataframe[PHASER_ROW_NUM] = [row.row_num for row in target]
             return dataframe
         except ImportError:

--- a/tests/test_end_to_end.py
+++ b/tests/test_end_to_end.py
@@ -30,7 +30,7 @@ def test_reporting(pipeline):
     assert "Beginning errors and warnings for Validator" in file_data
     assert "Employee Garak has no ID and inactive" in file_data
     assert "Beginning errors and warnings for Transformer" in file_data
-    assert "'Full name' was added to the row_data and not declared a header'" in file_data
+    assert "'Full name' was added to the row_data and not declared as a column'" in file_data
 
 
 def test_line_numbering(pipeline):

--- a/tests/test_multi_source_and_outputs.py
+++ b/tests/test_multi_source_and_outputs.py
@@ -54,7 +54,7 @@ def test_pipeline(tmpdir):
     assert "Beginning errors and warnings for Validation" in file_data
     assert "Employee Garak has no ID and inactive" in file_data
     assert "Beginning errors and warnings for Transformation" in file_data
-    assert "'Full name' was added to the row_data and not declared a header'" in file_data
+    assert "'Full name' was added to the row_data and not declared as a column'" in file_data
 
     # The extra output should be listed in the expected outputs.
     assert 'managers.csv' in pipeline.expected_outputs()

--- a/tests/test_steps.py
+++ b/tests/test_steps.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 
 import pandas
+import pandas as pd
 import pytest
 
 from phaser import (Phase, row_step, batch_step, context_step,
@@ -345,6 +346,22 @@ def test_dataframe_step_doesnt_return_df():
     with pytest.raises(PhaserError) as e:
         phase.run_steps()
     assert 'pandas DataFrame' in e.value.message
+
+
+def test_dataframe_step_is_testable():
+    # We want to make sure that a developer can write unit tests for their step functions.
+    # The @dataframe_step decorator should not make those unit tests unnecessarily complex.
+    @dataframe_step
+    def sum_bonuses(df, context):
+        df['total'] = df.sum(axis=1, numeric_only=True)
+        return df
+
+    data = {'eid': ['001', '001'], 'commission': [1000, 1000], 'performance': [9000, 1000]}
+    output = [{'eid': '001', 'commission': 1000, 'performance': 9000, 'total': 10000},
+              {'eid': '001', 'commission': 1000, 'performance': 1000, 'total': 2000}]
+    bonus_df = pd.DataFrame(data)
+    test_step_output, check_size_flag = sum_bonuses(bonus_df)
+    assert test_step_output == output
 
 
 def test_multiple_step_types():


### PR DESCRIPTION
We accidentally made it harder for a user of phaser to test their step by passing it dicts of data and checking that the result is also dicts with the successful data transformations.  This fixes that.