### PR TITLE
Adds a built-in step to drop duplicate rows.  While at it, also update docs for builtin steps generally.

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -86,6 +86,24 @@ All steps can accept a parameter named `context` which will be the
 .. autodecorator:: phaser.dataframe_step
 ```
 
+## Builtin steps
+
+```{eval-rst}
+.. autodecorator:: phaser.drop_duplicate_rows
+
+.. autodecorator:: phaser.check_unique
+
+.. autodecorator:: phaser.sort_by
+
+.. autodecorator:: phaser.filter_rows
+
+.. autodecorator:: phaser.flatten_all
+
+.. autodecorator:: phaser.flatten_column
+
+```
+
+
 ## Diff logic
 
 See [Checkpoint files](#checkpoint-files) and [Table-oriented diffs](#table-oriented-diffs) for how saving

--- a/phaser/__init__.py
+++ b/phaser/__init__.py
@@ -36,7 +36,7 @@ from phaser.constants import (PHASER_ROW_NUM, ON_ERROR_WARN, ON_ERROR_COLLECT, O
 from phaser.exceptions import PhaserError, DataErrorException, DataException, DropRowException, WarningException
 from phaser.phase import Phase
 from phaser.steps import row_step, batch_step, dataframe_step, context_step
-from phaser.builtin_steps import check_unique, sort_by, filter_rows, flatten_column, flatten_all
+from phaser.builtin_steps import check_unique, sort_by, filter_rows, flatten_column, flatten_all, drop_duplicate_rows
 from phaser.column import Column, IntColumn, DateColumn, DateTimeColumn, FloatColumn, BooleanColumn
 from phaser.io import read_csv, save_csv, ExtraMapping, ExtraRecords
 from phaser.table_diff import HtmlTableFormat, FormatterBase, IndexedTableDiffer

--- a/phaser/builtin_steps.py
+++ b/phaser/builtin_steps.py
@@ -3,14 +3,66 @@ from .exceptions import DataErrorException, PhaserError
 from .column import Column
 
 
+""" Contains builtin steps that can be added to Phase.steps directly.
+
+drop_duplicate_rows: Can drop rows if one, some or all column values are identical. E.g. 
+drop_duplicate_rows(['fn','ln'])
+check_unique: Can explicitly see if an important column is unique across the batch of data. Also supports multi-column. 
+Raises exceptions if duplicates are found. 
+
+"""
+
+def drop_duplicate_rows(columns=None):
+    """
+    This step factory will build a step to delete rows that are duplicates of each other, based on every value
+    or based on a list of columns or column names.  Consider also using DropRowException in a custom row_step if
+    the logic doesn't conveniently fit in this built-in.
+
+    :param columns: A list of the columns that are checked to determine if a row is a duplicate. ``columns=None``  \
+    (which is the parameter default) may be used to apply to all columns.
+    :return: Returns a function that can be used as a step in a phaser pipeline.
+
+    Example usage:
+
+    .. code-block:: python
+
+        phase.steps = [drop_duplicate_rows('guid')]
+
+    """
+
+    @batch_step(check_size=False)
+    def drop_duplicate_rows_step(batch, context, **kwargs):
+        # Need an algorithm that is reasonable for now, and doesn't depend on pandas
+        if columns is None:
+            key_columns = batch[0].keys()
+        elif isinstance(columns, str):
+            key_columns = [columns]
+        else:
+            key_columns = columns
+        index = {}
+        for row in batch:
+            key = '|'.join([str(row[col]) for col in key_columns])
+            index[key] = row
+
+        num_dropped = len(batch) - len(index)
+        if num_dropped > 0:
+            context.add_dropped_row(step='drop_duplicate_rows_step',
+                                    row=None,
+                                    message=f"{num_dropped} rows dropped by drop_duplicate_rows(columns={key_columns})")
+        return list(index.values())
+
+    return drop_duplicate_rows_step
+
+
 def check_unique(column, strip=True, ignore_case=False):
     """ This is a step factory that will create a step that tests that all the values in a column
     are unique with respect to each other.  It does not change any values permanently (strip spaces
     or lower-case letters).
-    Params
-    column: the column class or name of the column in which all values should be unique.
-    strip(defaults to True): whether to strip spaces from all values
-    ignore_case(defaults to False): whether to lower-case all values
+
+    :param column: The column class or name of the column in which all values should be unique.
+    :param strip: whether to strip spaces from all values (defaults to True)
+    :param ignore_case: whether to lower-case all values (defaults to False)
+    :return: Returns a function that can be used as a step in a phaser pipeline
     """
     def safe_strip(value):
         return value.strip() if isinstance(value, str) else value
@@ -37,6 +89,7 @@ def check_unique(column, strip=True, ignore_case=False):
 def sort_by(column):
     """
     This is a step factory that will create a step that orders rows by the values in a give column.
+
     :param column: The column that will be ordered by when the step is run
     :return: The function that can be added to a phase's list of steps.
     """
@@ -58,11 +111,18 @@ def filter_rows(func):
     """
     This step factory will keep only specified rows. While there are other ways to accomplish the same thing, many of
     those create a DROPPED_ROW message for each dropped row.  This will summarize how many rows were dropped.
+    Consider also using DropRowException in a custom row_step if the logic doesn't conveniently fit in this built-in.
+
+    :param func: The function that, if it returns true, will result in each row being kept.
+    :return: A function that can be added to a phase's list of steps.
+
     Usage:
 
-    filter_rows(lambda row: row['type'] == 'basal')
-    filter_rows(lambda row: row['type'] != None)
-    filter_rows(lambda row: row['sampleSize'] > 5)  # depends on sampleSize being an IntColumn or cast to int before
+    .. code-block:: python
+
+        filter_rows(lambda row: row['type'] == 'basal')
+        filter_rows(lambda row: row['type'] != None)
+        filter_rows(lambda row: row['sampleSize'] > 5)  # depends on sampleSize being an IntColumn or cast to int before
 
     """
 
@@ -80,6 +140,25 @@ def filter_rows(func):
 
 @row_step
 def flatten_all(row, context, **kwargs):
+    """
+    The flatten_all step is useful in JSON data handling, which often has value fields within JSON-formatted
+    fields within records.  In flattening, new column names are concatenated from hierarchical names.
+    For example, flattening a column called 'payload' which is a dict with fields called 'type' and 'id' will create
+    one new column for each key called 'payload__type' and 'payload__id'.
+
+    This function can be used directly as a step in a Phase and does not take any parameters.
+
+    Usage:
+
+    .. code-block:: python
+
+        phase = phaser.Phase(
+            name='extract',
+            steps=[flatten_all, drop_duplicate_rows['payload__id']]
+        )
+
+    """
+
     new_row = row
     still_flattening = True
     while still_flattening:
@@ -110,14 +189,21 @@ def _merge_values_if_no_collisions(row, key_name):
 def flatten_column(column_name, deep=True):
     """
     The flatten_column step is useful in JSON data handling, which often has value fields within JSON-formatted
-    fields within records.  In flattening, new column names are concatenated from hierarchical names.
-    For example, flattening a column called 'payload' which is a dict with fields called 'type' and 'id' will create
-    one new column for each key called 'payload__type' and 'payload__id'.
+    fields within records.   Names are concatenated with '__' as with `flatten_all`.  Only chosen columns
+    are flattened in this usage.
+
+    :param column_name: The name of the column with internal substructure to flatten into multiple columns.
+    :param deep: Whether to iterate and flatten substructure within the substructure of the column. Defaults to True.
+    :return: Returns a function that can be used as a step in a Phase.
 
     Usage:
 
-    flatten_column('payload')
-    flatten_column('performance_detail', deep=False)  # Only flatten one layer -- if there are dicts within dict
+    .. code-block:: python
+
+        phase.steps = [
+            flatten_column('payload')
+            flatten_column('performance_detail', deep=False)  # Only flatten one layer into the substructure.
+        ]
 
     """
 


### PR DESCRIPTION
Although people can drop rows with a custom step, dropping duplicates is common enough (and benefits from the reporting of exactly how many were dropped) that this seems like a good builtin.