### PR TITLE
Fixes quoting with backticks that caused errors in docstring buildds

### DIFF
--- a/phaser/column.py
+++ b/phaser/column.py
@@ -37,7 +37,7 @@ class Column:
         such as a builtin 'capitalize' or a custom function defined in scope.
     :param rename: A set of alternate names that may be used for this column, all of which should be mapped to
         the preferred name of this column. Upon loading the data, all rows that have columns matching
-        any alternate name in this set will have the alternate name replaced with the preferred `name` value.
+        any alternate name in this set will have the alternate name replaced with the preferred 'name' value.
     :param allowed_values: If allowed_values is empty or None, it is not checked.  If allowed_values is a
         single value or list of values, column logic checks every row to see that values are in the allowed list.
     :param save: if True, column is saved at the end of the phase; if not it is omitted.
@@ -130,7 +130,7 @@ class Column:
     def cast(self, value):
         """
         When subclassing Column to provide a custom column type, override the `cast` method to do type-casting.
-        For example, the builtin IntColumn uses this method to cast to an `int`.
+        For example, the builtin IntColumn uses this method to cast to an int.
 
         :param value: this parameter will hold a single value from the column, for this method to cast
             to the correct data type.
@@ -164,8 +164,8 @@ class Column:
     def fix_value(self, value):
         """
         When subclassing Column to provide custom data cleaning in a re-usable form, override the 'fix_value'
-        method.  The default implementation of this method applies the `default` parameter value and
-        also applies functions passed into the `fix_value_fn` parameter.  This is called after casting the
+        method.  The default implementation of this method applies the 'default' parameter value and
+        also applies functions passed into the 'fix_value_fn' parameter.  This is called after casting the
         column to the appropriate date type if using IntColumn, DateColumn, etc.
 
         Tips:
@@ -235,7 +235,7 @@ class IntColumn(Column):
     :param rename: A set of names that may be used in the data as column headers, all of which should be mapped to
         the preferred name of this column. Upon loading the data, all rows that have columns matching
         any alternate name in this set will have a column with the preferred name with the same data in
-        it. In other words, any data in a column name in `rename` will end up in a column named `name`.
+        it. In other words, any data in a column name in 'rename' will end up in a column named 'name'.
     :param allowed_values: If allowed_values is not empty and a column value is not in the list, raises errors.
         To supply a range, use min_value and max_value instead.  NOTE: this is checked after casting,
         so to check allowed values of a column specified to cast to int, such as IntColumn, check for
@@ -308,7 +308,7 @@ class DateTimeColumn(Column):
     :param rename: A set of names that may be used in the data as column headers, all of which should be mapped to
         the preferred name of this column. Upon loading the data, all rows that have columns matching
         any alternate name in this set will have a column with the preferred name with the same data in
-        it. In other words, any data in a column name in `rename` will end up in a column named `name`.
+        it. In other words, any data in a column name in 'rename' will end up in a column named 'name'.
     :param allowed_values: If allowed_values is not empty and a column value is not in the list, raises errors.
         To supply a range, use min_value and max_value instead.
     :param save: if True, column is saved at the end of the phase; if not it is omitted.
@@ -392,7 +392,7 @@ class DateColumn(DateTimeColumn):
     :param rename: A set of names that may be used in the data as column headers, all of which should be mapped to
         the preferred name of this column. Upon loading the data, all rows that have columns matching
         any alternate name in this set will have a column with the preferred name with the same data in
-        it. In other words, any data in a column name in `rename` will end up in a column named `name`.
+        it. In other words, any data in a column name in 'rename' will end up in a column named 'name'.
     :param allowed_values: If allowed_values is not empty and a column value is not in the list, raises errors.
         To supply a range, use min_value and max_value instead.
     :param save: if True, column is saved at the end of the phase; if not it is omitted.

--- a/phaser/steps.py
+++ b/phaser/steps.py
@@ -163,12 +163,12 @@ def batch_step(func=None, *, extra_sources=None, extra_outputs=None, check_size=
 
 def dataframe_step(func=None, *, pass_row_nums=True, extra_sources=None, extra_outputs=None, check_size=False):
     """
-    Used to define a step that needs to run on the whole set of data as a `pandas.DataFrame`.
+    Used to define a step that needs to run on the whole set of data as a pandas.DataFrame.
 
     The decorated function should accept a DataFrame as its first parameter.
 
     :param pass_row_nums: If True, the row numbers will be set in the DataFrame
-        in a column named the value of `PHASER_ROW_NUM`
+        in a column named the value of PHASER_ROW_NUM
     :param extra_sources: An array of source names
     :param extra_output: An array of names of outputs
     :param check_size: A boolean indicating whether or not to validate the size of the


### PR DESCRIPTION
Only references that sphinx recognizes should be quoted with backticks - a reference to another class that's documented
would work with `TheClass` but a reference to a parameter name of the function should be 'my_param' (apostrophe) or "my_param" (double-quote) I think