### PR TITLE
Replaces a cryptic error with more helpful one

### DIFF
--- a/phaser/io.py
+++ b/phaser/io.py
@@ -229,6 +229,9 @@ class ExtraMapping(SavableObject):
         super().__init__(name, Mapping, data)
 
     def load_data(self, tabular_data):
+        if 'key' not in tabular_data[0].keys():
+            raise Exception(f"""Extra mapping data '{self.name}' loaded in for use needs to be formatted as a mapping
+                - specifically needs 'key' column and 'value' column""")
         self.data = {
             row['key']: row['value'] for row in tabular_data
         }


### PR DESCRIPTION
I was trying to set up a new phaser pipeline (new york bicycle data) and ran into an error running the pipeline with an extra data source.

```
(venv) lisa@LisaPerlAir2021 bikecounts % python3 -m phaser run --counter_info=counters.csv newyork output "sources/NYC Bicycle Counts.csv"
ERROR running 'run': 'key'
--------------------------------------------------------------------------------------------------------------------------------------------------

usage: phaser run [-h] [--error-policy {ON_ERROR_WARN,ON_ERROR_COLLECT,ON_ERROR_DROP_ROW,ON_ERROR_STOP_NOW}] --counter_info COUNTER_INFO
                  pipeline_name working_dir source
. . .
```

The "ERROR running 'run': 'key'" error doesn't say much about where the frequently-used 'key' might need to be.

New error message is now
```
(venv) lisa@LisaPerlAir2021 bikecounts % python3 -m phaser run --counter_info=counters.csv newyork output "sources/NYC Bicycle Counts.csv"
ERROR running 'run': Extra mapping data 'counter_info' loaded in for use needs to be formatted as a mapping
                - specifically needs 'key' column and 'value' column
               
```